### PR TITLE
replace optional:false with required:true for flags

### DIFF
--- a/commands/delete_topic.js
+++ b/commands/delete_topic.js
@@ -48,7 +48,7 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   flags: [
-    {name: 'topic', char: 't', description: 'topic name to delete', hasValue: true, optional: false}
+    {name: 'topic', char: 't', description: 'topic name to delete', hasValue: true, required: true}
   ],
   run: cli.command(co.wrap(deleteTopic))
 };

--- a/commands/tail.js
+++ b/commands/tail.js
@@ -73,7 +73,7 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   flags: [
-    {name: 'topic', char: 't', description: 'topic name to tail from', hasValue: true, optional: false}
+    {name: 'topic', char: 't', description: 'topic name to tail from', hasValue: true, required: true}
   ],
   run: cli.command(co.wrap(tail))
 };

--- a/commands/write.js
+++ b/commands/write.js
@@ -56,11 +56,11 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   flags: [
-    {name: 'topic', char: 't', description: 'topic name to write to', hasValue: true, optional: false},
+    {name: 'topic', char: 't', description: 'topic name to write to', hasValue: true, required: true},
     {name: 'partition', char: 't', description: 'partition to write to', hasValue: true, optional: true}
   ],
   args: [
-    {name: 'message', optional: false, hidden:false}
+    {name: 'message', required: true, hidden:false}
   ],
   run: cli.command(co.wrap(write))
 };


### PR DESCRIPTION
Flags don't have an 'optional' parameter but do have 'required' - see:

https://github.com/heroku/heroku-cli/blob/332e03c31f4b264a75e839d5708cd2f16b224865/flag.go#L16

This plugin currently sets 'optional' to false which has no effect - 

```
$ heroku kafka:topics:create
/Users/canderton/Projects/heroku-kafka-jsplugin/commands/shared.js:17
  if (topicName.length <= 0) {
               ^

TypeError: Cannot read property 'length' of undefined
    at checkValidTopicName (/Users/canderton/Projects/heroku-kafka-jsplugin/commands/shared.js:17:16)
```

This pull request replaces usage of 'optional' with 'required' to enforce required flags - after this commit is applied:

```
$ heroku kafka:topics:create
 ▸    Required flag:  -t, --topic TOPIC
```
