### PR TITLE
add missing 'finished' definition

### DIFF
--- a/commands/topics.js
+++ b/commands/topics.js
@@ -11,7 +11,7 @@ class TopicList {
     that.listTopics(function (topics) {
       if (topics.length === 0) {
         console.log("No topics found");
-        this.finished();
+        that.finished();
       }
       for (var i = 0; i < topics.length; i++) {
         var topicName = topics[i];
@@ -81,6 +81,10 @@ class TopicList {
 
   error(error) {
     cli.error(error);
+    this.client.close();
+  }
+  
+  finished() {
     this.client.close();
   }
 }


### PR DESCRIPTION
Finished is not defined - called when there are no topics:

```
$ heroku kafka:topics:list
No topics found
/Users/canderton/Projects/heroku-kafka-jsplugin/commands/topics.js:14
        this.finished();
            ^

TypeError: Cannot read property 'finished' of undefined
```

Copied implementation from create_topic and also modified from 'this' to 'that' for the right context - output works as expected with commit applied:

```
$ heroku kafka:topics:list
No topics found
$
```
