### PR TITLE
use attachment name in kafka:info if present

### DIFF
--- a/commands/info.js
+++ b/commands/info.js
@@ -10,7 +10,7 @@ function* kafkaInfo (context, heroku) {
   var infos = yield new HerokuKafkaClusters(heroku, process.env, context).info(context.args.CLUSTER);
   if (infos) {
     _.each(infos, function(info) {
-      console.log('=== HEROKU_KAFKA');
+      console.log('=== ' + (info.attachment_name || 'HEROKU_KAFKA'));
       console.log(columnify(info.info, {showHeaders: false, preserveNewLines: true}));
       console.log();
     });


### PR DESCRIPTION
While we're creating the resource, this isn't known, so just fallback to
a catchall `HEROKU_KAFKA`
