### PR TITLE
add kafka:list

### DIFF
--- a/commands/clusters.js
+++ b/commands/clusters.js
@@ -35,6 +35,17 @@ HerokuKafkaClusters.prototype.topic = function* (cluster, topic) {
   }
 };
 
+HerokuKafkaClusters.prototype.topics = function* (cluster) {
+  var addon = yield this.addonForSingleClusterCommand(cluster);
+  if (addon) {
+    return yield this.request({
+      path: `/client/kafka/${VERSION}/clusters/${addon.name}/topics`
+    });
+  } else {
+    return null;
+  }
+};
+
 HerokuKafkaClusters.prototype.fail = function* (cluster, catastrophic, zk) {
   var addon = yield this.addonForSingleClusterCommand(cluster);
   if (addon) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "co-sleep": "0.0.1",
     "columnify": "^1.4.1",
     "eslint": "^1.2.1",
-    "heroku-cli-util": "^5.4.5",
+    "heroku-cli-util": "^5.6.3",
     "kafkaesque": "^0.1.1",
     "node-spinner": "0.0.4",
     "node-zookeeper-client": "^0.2.2",


### PR DESCRIPTION
looks like this:

``` bash
$ heroku kafka:list
=== Kafka Topics on HEROKU_KAFKA_TCRAYFORD_URL

Name                Messages  Traffic
──────────────────  ────────  ───────────
page-visits-6       0.0/sec   0 bytes/sec
page-visits-8       0.0/sec   0 bytes/sec
page-visits-5       0.0/sec   0 bytes/sec
page-visits-7       0.0/sec   0 bytes/sec
tom-test-2          0.0/sec   0 bytes/sec
tom-test-3          0.0/sec   0 bytes/sec
tom-test-1          0.0/sec   0 bytes/sec
__consumer_offsets  0.0/sec   0 bytes/sec
page_visits2        0.0/sec   0 bytes/sec
```

I didn't include consumer count for now (even though it's in the spec) because it's expensive to query.
