### PR TITLE
don't overwrite compaction in kafka:configure

### DIFF
--- a/commands/clusters.js
+++ b/commands/clusters.js
@@ -103,11 +103,10 @@ HerokuKafkaClusters.prototype.configureTopic = function* (cluster, topicName, fl
       method: 'PUT',
       body: {
         topic:
-          {
+          _.extend({
             name: topicName,
             retention_time_ms: flags['retention-time'],
-            compaction: flags['compaction'] || false
-          }
+          }, this.compactionSettingFromFlags(flags))
       },
       path: `/client/kafka/${VERSION}/clusters/${addon.name}/topics/${topicName}`
     }).catch(function (err) { return err; });
@@ -117,6 +116,15 @@ HerokuKafkaClusters.prototype.configureTopic = function* (cluster, topicName, fl
   }
 };
 
+HerokuKafkaClusters.prototype.compactionSettingFromFlags = function* (flags) {
+  if (flags['no-compaction']) {
+    return { compaction: false };
+  } else if (flags['compaction']) {
+    return { compaction: true };
+  } else {
+    return {};
+  }
+}
 
 HerokuKafkaClusters.prototype.deleteTopic = function* (cluster, topicName) {
   var addon = yield this.addonForSingleClusterCommand(cluster);

--- a/commands/configure_topic.js
+++ b/commands/configure_topic.js
@@ -1,8 +1,9 @@
 'use strict';
 
 let FLAGS = [
-  {name: 'retention-time',      char: 't', description: 'The length of time messages in the topic should be retained for.',  hasValue: true,  optional: true},
-  {name: 'compaction',          char: 'c', description: 'Whether to use compaction for this topi',                           hasValue: false, optional: true}
+  {name: 'retention-time', char: 't', description: 'The length of time messages in the topic should be retained for.',  hasValue: true,  optional: true},
+  {name: 'compaction',     char: 'c', description: 'Enables compaction on the topic if passed',                          hasValue: false, optional: true}
+  {name: 'no-compaction',  char: 'c', description: 'Disables compaction on the topic if passed',                         hasValue: false, optional: true}
 ];
 let DOT_WAITING_TIME = 200;
 
@@ -35,7 +36,10 @@ function* printWaitingDots() {
 }
 
 function* configureTopic (context, heroku) {
-  if (context.args.CLUSTER) {
+  if (context.flags['no-compaction'] && context.flags['compaction']) {
+    cli.error("can't pass both no-compaction and compaction");
+    process.exit(1);
+  } else if (context.args.CLUSTER) {
     process.stdout.write(`Configuring ${context.args.TOPIC} on ${context.args.CLUSTER}`);
   } else {
     process.stdout.write(`Configuring ${context.args.TOPIC}`);

--- a/commands/create_topic.js
+++ b/commands/create_topic.js
@@ -4,7 +4,7 @@ let FLAGS = [
   {name: 'partitions',          char: 'p', description: 'number of partitions to give the topic',                            hasValue: true,  optional: false},
   {name: 'replication-factor',  char: 'r', description: 'number of replicas the topic should be created across',             hasValue: true,  optional: true},
   {name: 'retention-time',      char: 't', description: 'The length of time messages in the topic should be retained for.',  hasValue: true,  optional: true},
-  {name: 'compaction',          char: 'c', description: 'Whether to use compaction for this topi',                           hasValue: false, optional: true}
+  {name: 'compaction',          char: 'c', description: 'Whether to use compaction for this topic',                          hasValue: false, optional: true}
 ];
 let DOT_WAITING_TIME = 200;
 


### PR DESCRIPTION
if compaction is on or off currently, we'll mutate it when we run
kafka:configure - e.g. if it's currently on and you call
`kafka:configure` without passing `--compaction`, compaction will be
disabled. This prevents that case from happening, once
https://github.com/heroku/shogun/commit/966c8a3fe4eb1292238b594e9a9230ce54162577
is shipped.
