### PR TITLE
Fix formatting for kafka:create

### DIFF
--- a/commands/create_topic.js
+++ b/commands/create_topic.js
@@ -53,7 +53,7 @@ function* createTopic (context, heroku) {
     cli.error(err);
   } else {
     process.stdout.write(' done.\n');
-    process.stdout.write(`Use \`heroku kafka:topic ${context.args.TOPIC}\` to monitor your topic`);
+    process.stdout.write(`Use \`heroku kafka:topic ${context.args.TOPIC}\` to monitor your topic.\n`);
   }
 }
 


### PR DESCRIPTION
before:

``` console
maciek@mothra:~$ h kafka:create test --app pg-kafka-search
Creating test... done.
Use `heroku kafka:topic test` to monitor your topicmaciek@mothra:~$ 
```

after:

``` console
maciek@mothra:~$ h kafka:create test --app pg-kafka-search
Creating test... done.
Use `heroku kafka:topic test` to monitor your topic.
maciek@mothra:~$ 
```
