### PR TITLE
use kafka api host

### DIFF
--- a/commands/clusters.js
+++ b/commands/clusters.js
@@ -4,7 +4,7 @@ let _ = require('underscore');
 let cli = require('heroku-cli-util');
 
 let VERSION = "v0";
-let DEFAULT_HOST = "postgres-api.heroku.com";
+let DEFAULT_HOST = "kafka-api.heroku.com";
 
 function HerokuKafkaClusters(heroku, env, context) {
   this.heroku = heroku;


### PR DESCRIPTION
A new host was created `kafka-api.heroku.com` lets use that for the kafka plugin.
