### PR TITLE
don't spam heroku api during kafka wait

### DIFF
--- a/commands/clusters.js
+++ b/commands/clusters.js
@@ -61,8 +61,7 @@ HerokuKafkaClusters.prototype.fail = function* (cluster, catastrophic, zk) {
   }
 };
 
-HerokuKafkaClusters.prototype.waitStatus = function* (cluster) {
-  var addon = yield this.addonForSingleClusterCommand(cluster);
+HerokuKafkaClusters.prototype.waitStatus = function* (addon) {
   if (addon) {
     var response = yield this.request({
       path: `/client/kafka/${VERSION}/clusters/${addon.name}/wait_status`

--- a/commands/wait.js
+++ b/commands/wait.js
@@ -7,14 +7,19 @@ var Spinner = require('node-spinner');
 function* kafkaWait (context, heroku) {
   var finished = false;
   var s = Spinner();
-  while (!finished) {
-    var waitStatus = yield new HerokuKafkaClusters(heroku, process.env, context).waitStatus(context.args.CLUSTER);
-    if (!waitStatus || !waitStatus['waiting?']) {
-      finished = true;
-    } else {
-      process.stdout.write("\r \033[36m" + waitStatus.message + "\033[m " + s.next());
-      yield sleep(500);
+  var addon = yield new HerokuKafkaClusters(heroku, process.env, context).addonForSingleClusterCommand(context.args.CLUSTER);
+  if (addon) {
+    while (!finished) {
+      var waitStatus = yield new HerokuKafkaClusters(heroku, process.env, context).waitStatus(addon);
+      if (!waitStatus || !waitStatus['waiting?']) {
+        finished = true;
+      } else {
+        process.stdout.write("\r \033[36m" + waitStatus.message + "\033[m " + s.next());
+        yield sleep(500);
+      }
     }
+  } else {
+    process.exit(1)
   }
 }
 


### PR DESCRIPTION
`heroku kafka:wait` has to make _two_ http requests. One for listing all
the addons available to this app (it does this to match against config
vars, so you can do e.g. `heroku kafka:wait HEROKU_KAFKA_BROWN_URL`),
and then one to shogun to check the status of the kafka cluster.
Before this commit, we issued _both_ http requests on every tick. Now we
just issue a single one to heroku api to check against addons, and once
that works we then just poll shogun repeatedly.
There isn't an authentication issue here because shogun already checks
for the user's access to the cluster in `FormationFinder`.
