### PR TITLE
Exit 1 correctly when 0 attachments exist

### DIFF
--- a/commands/info.js
+++ b/commands/info.js
@@ -7,7 +7,7 @@ let _ = require('underscore');
 
 function* kafkaInfo (context, heroku) {
   var infos = yield new HerokuKafkaClusters(heroku, process.env, context).info(context.args.CLUSTER);
-  if (infos) {
+  if (infos.length !== 0) {
     _.each(infos, function(info) {
       cli.styledHeader(info.attachment_name || 'HEROKU_KAFKA');
       console.log();


### PR DESCRIPTION
We changed how the cluster code worked, but didn't change the info command. 
