### PR TITLE
Fix compaction flags for kafka:configure

### DIFF
--- a/commands/clusters.js
+++ b/commands/clusters.js
@@ -115,7 +115,7 @@ HerokuKafkaClusters.prototype.configureTopic = function* (cluster, topicName, fl
   }
 };
 
-HerokuKafkaClusters.prototype.compactionSettingFromFlags = function* (flags) {
+HerokuKafkaClusters.prototype.compactionSettingFromFlags = function (flags) {
   if (flags['no-compaction']) {
     return { compaction: false };
   } else if (flags['compaction']) {


### PR DESCRIPTION
Make `compactionSettingFromFlags` non-async to unbreak the flags
