### PR TITLE
Correctly pass the CLUSTER argument in kafka:tail

### DIFF
--- a/commands/tail.js
+++ b/commands/tail.js
@@ -13,7 +13,7 @@ const MAX_LENGTH = 80;
 
 function* tail(context, heroku) {
   let clusters = new HerokuKafkaClusters(heroku, process.env, context);
-  let addon = yield clusters.addonForSingleClusterCommand();
+  let addon = yield clusters.addonForSingleClusterCommand(context.args.CLUSTER);
   if (!addon) {
     process.exit(1);
   }


### PR DESCRIPTION
Totally missed actually passing in the CLUSTER argument.
