### PR TITLE
Allow units on retention time

### DIFF
--- a/commands/configure_topic.js
+++ b/commands/configure_topic.js
@@ -10,6 +10,7 @@ let DOT_WAITING_TIME = 200;
 let cli = require('heroku-cli-util');
 let co = require('co');
 let HerokuKafkaClusters = require('./clusters.js').HerokuKafkaClusters;
+let parseDuration = require('./shared').parseDuration;
 let sleep = require('co-sleep');
 let _ = require('underscore');
 
@@ -19,8 +20,17 @@ function extractFlags(contextFlags) {
   // (if there happen to be any).
   var out = {};
   _.each(FLAGS, function (flag) {
-    if (contextFlags[flag.name] !== undefined) {
-      out[flag.name] = contextFlags[flag.name];
+    let value = contextFlags[flag.name];
+    if (value !== undefined) {
+      if (flag.name === 'retention-time') {
+        let parsed = parseDuration(value);
+        if (value == null) {
+          cli.error(`could not parse retention time '${value}'`);
+          process.exit(1);
+        }
+        value = parsed;
+      }
+      out[flag.name] = value;
     }
   });
   return out;
@@ -68,8 +78,8 @@ module.exports = {
 
     Examples:
 
-    $ heroku kafka:configure page-visits --retention-time 86400000
-    $ heroku kafka:configure HEROKU_KAFKA_BROWN_URL page-visits --retention-time 86400000 --compaction
+    $ heroku kafka:configure page-visits --retention-time '1 day'
+    $ heroku kafka:configure HEROKU_KAFKA_BROWN_URL page-visits --retention-time '1 day' --compaction
 `,
   needsApp: true,
   needsAuth: true,

--- a/commands/shared.js
+++ b/commands/shared.js
@@ -26,6 +26,52 @@ function clusterConfig(addon, config) {
   };
 }
 
+function parseDuration(durationStr) {
+  if (/^\d+$/.test(durationStr)) {
+    return parseInt(durationStr, 10);
+  } else {
+    let result = durationStr.match(/^(\d+) ?(ms|[smhd]|milliseconds?|seconds?|minutes?|hours?|days?)$/);
+    if (result) {
+      let magnitude = parseInt(result[1]);
+      let unit = result[2];
+      let multiplier = 1;
+      switch (unit) {
+      case 'ms':
+      case 'millisecond':
+      case 'milliseconds':
+        multiplier = 1;
+        break;
+      case 's':
+      case 'second':
+      case 'seconds':
+        multiplier = 1000;
+        break;
+      case 'm':
+      case 'minute':
+      case 'minutes':
+        multiplier = 1000 * 60;
+        break;
+      case 'h':
+      case 'hour':
+      case 'hours':
+        multiplier = 1000 * 60 * 60;
+        break;
+      case 'd':
+      case 'day':
+      case 'days':
+        multiplier = 1000 * 60 * 60 * 24;
+        break;
+      default:
+        return null;
+      }
+      return magnitude * multiplier;
+    } else {
+      return null;
+    }
+  }
+}
+
 module.exports = {
-  clusterConfig: clusterConfig
+  clusterConfig: clusterConfig,
+  parseDuration: parseDuration
 };

--- a/test/index.js
+++ b/test/index.js
@@ -2,11 +2,52 @@
 
 require('chai').should();
 var index = require('../index.js');
+var shared = require('../commands/shared.js');
 
 describe('commands', function () {
   index.commands.forEach(function(command) {
     it(`${command.topic}:${command.command} takes a CLUSTER argument`, function () {
       command.args.map(function (arg) { return arg.name; }).should.include('CLUSTER');
     });
+  });
+});
+
+
+describe('parseDuration', function() {
+  let cases = [
+    ['10', 10],
+    ['10ms', 10],
+    ['10 ms', 10],
+    ['10 milliseconds', 10],
+    ['1 millisecond', 1],
+
+    ['10s', 10 * 1000],
+    ['10 s', 10 * 1000],
+    ['1 second', 1 * 1000],
+    ['10 seconds', 10 * 1000],
+
+    ['10m', 10 * 1000 * 60],
+    ['10 m', 10 * 1000 * 60],
+    ['1 minute', 1 * 1000 * 60],
+    ['10 minutes', 10 * 1000 * 60],
+
+    ['10h', 10 * 1000 * 60 * 60],
+    ['10 h', 10 * 1000 * 60 * 60],
+    ['1 hour', 1 * 1000 * 60 * 60],
+    ['10 hours', 10 * 1000 * 60 * 60],
+
+    ['10d', 10 * 1000 * 60 * 60 * 24],
+    ['10 d', 10 * 1000 * 60 * 60 * 24],
+    ['1 day', 1 * 1000 * 60 * 60 * 24],
+    ['10 days', 10 * 1000 * 60 * 60 * 24]
+  ];
+  cases.forEach(function(testcase) {
+    let duration = testcase[0];
+    let expected = testcase[1];
+
+    it(`parses '${duration}' as '${expected}'`, function() {
+      let actual = shared.parseDuration(duration);
+      actual.should.equal(expected);
+    })
   });
 });


### PR DESCRIPTION
I'm punting on the `extractFlags` duplication. Something like https://github.com/heroku/cli/issues/265 would make this better, but I think moving the function into `shared.js` without something like that would be worse than the duplication, since it's weird to `exit()` there on flag validation (though I'm on the fence; I can move it if you think that's better).