### PR TITLE
Clean up docs

### DIFF
--- a/commands/configure_topic.js
+++ b/commands/configure_topic.js
@@ -1,9 +1,9 @@
 'use strict';
 
 let FLAGS = [
-  {name: 'retention-time', description: 'The length of time in milliseconds messages in the topic should be retained for.',  hasValue: true,  optional: true},
-  {name: 'compaction',     description: 'Enables compaction on the topic if passed',                                         hasValue: false, optional: true},
-  {name: 'no-compaction',  description: 'Disables compaction on the topic if passed',                                        hasValue: false, optional: true}
+  {name: 'retention-time', description: 'length of time messages in the topic should be retained for',  hasValue: true,  optional: true},
+  {name: 'compaction',     description: 'enables compaction on the topic if passed',                    hasValue: false, optional: true},
+  {name: 'no-compaction',  description: 'disables compaction on the topic if passed',                   hasValue: false, optional: true}
 ];
 let DOT_WAITING_TIME = 200;
 

--- a/commands/create_topic.js
+++ b/commands/create_topic.js
@@ -1,11 +1,11 @@
 'use strict';
 
 let FLAGS = [
-  {name: 'partitions',          description: 'number of partitions to give the topic',                                            hasValue: true,  optional: false},
-  {name: 'replication-factor',  description: 'number of replicas the topic should be created across',                             hasValue: true,  optional: true},
-  {name: 'retention-time',      description: 'the length of time messages in the topic should be retained for in milliseconds.',  hasValue: true,  optional: true},
-  {name: 'compaction',          description: 'whether to use compaction for this topic',                                          hasValue: false, optional: true},
-  {name: 'confirm',             description: 'override the confirmation prompt. Needs the app name, or the command will fail.',   hasValue: true, optional: true}
+  {name: 'partitions',          description: 'number of partitions to give the topic',                                          hasValue: true,  optional: false},
+  {name: 'replication-factor',  description: 'number of replicas the topic should be created across',                           hasValue: true,  optional: true},
+  {name: 'retention-time',      description: 'length of time messages in the topic should be retained for',                     hasValue: true,  optional: true},
+  {name: 'compaction',          description: 'whether to use compaction for this topic',                                        hasValue: false, optional: true},
+  {name: 'confirm',             description: 'override the confirmation prompt (needs the app name, or the command will fail)', hasValue: true,  optional: true}
 ];
 let DOT_WAITING_TIME = 200;
 


### PR DESCRIPTION
 * Remove obsolete 'in milliseconds' from relevant options
 * Change naming to be more consistent with style guidelines https://devcenter.heroku.com/articles/cli-style-guide?preview=1