### PR TITLE
better text when upgrading clusters

### DIFF
--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -43,8 +43,10 @@ function * upgradeCluster (context, heroku) {
     cli.error(err)
     process.exit(1)
   } else {
-    process.stdout.write(' done.\n')
-    process.stdout.write(`Use \`heroku kafka:info\` to monitor the upgrade.\n`)
+    process.stdout.write(' started.\n\n')
+    process.stdout.write('Upgrading versions on a cluster involves rolling restarts\n')
+    process.stdout.write('and takes some time, depending on the size of the cluster\n\n')
+    process.stdout.write(`Use \`heroku kafka:wait\` to monitor the upgrade.\n`)
   }
 }
 


### PR DESCRIPTION
currently our upgrade text says `done` when it's really just `started`

```
Upgrading to version 0.10... done.
Use `heroku kafka:info` to monitor the upgrade.
```

This changes it to document things a bit more clearly.