### PR TITLE
fix --confirm

### DIFF
--- a/commands/create_topic.js
+++ b/commands/create_topic.js
@@ -86,7 +86,10 @@ module.exports = {
     { name: 'partitions', description: 'number of partitions to give the topic', hasValue: true, required: true },
     { name: 'replication-factor', description: 'number of replicas the topic should be created across', hasValue: true },
     { name: 'retention-time', description: 'length of time messages in the topic should be retained for', hasValue: true },
-    { name: 'compaction', description: 'whether to use compaction for this topic', hasValue: false }
+    { name: 'compaction', description: 'whether to use compaction for this topic', hasValue: false },
+    { name: 'confirm',
+      description: 'pass the app name to skip the manual confirmation prompt',
+      hasValue: true, required: false }
   ],
   run: cli.command(co.wrap(createTopic))
 }

--- a/commands/delete_topic.js
+++ b/commands/delete_topic.js
@@ -66,5 +66,10 @@ module.exports = {
     { name: 'TOPIC' },
     { name: 'CLUSTER', optional: true }
   ],
+  flags: [
+    { name: 'confirm',
+      description: 'pass the app name to skip the manual confirmation prompt',
+      hasValue: true, required: false }
+  ],
   run: cli.command(co.wrap(deleteTopic))
 }

--- a/commands/fail.js
+++ b/commands/fail.js
@@ -70,7 +70,10 @@ module.exports = {
     hasValue: false },
     { name: 'zookeeper',
       description: 'induce failure on zookeeper node rather than on Kafka itself',
-    hasValue: false }
+    hasValue: false },
+    { name: 'confirm',
+      description: 'pass the app name to skip the manual confirmation prompt',
+      hasValue: true, required: false }
   ],
   run: cli.command(co.wrap(fail))
 }

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -70,7 +70,10 @@ module.exports = {
   flags: [
     { name: 'version',
       description: 'requested kafka version for upgrade',
-    hasValue: true, required: true }
+    hasValue: true, required: true },
+    { name: 'confirm',
+      description: 'pass the app name to skip the manual confirmation prompt',
+      hasValue: true, required: false }
   ],
   run: cli.command(co.wrap(upgradeCluster))
 }


### PR DESCRIPTION
https://github.com/heroku/heroku-kafka-jsplugin/commit/0547ffd15c317952f14f150944fbd7aba1c94c7e
removed all the `confirm` from `flags`. These are needed, without them
`--confirm` never works.