### PR TITLE
invert readme orders for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,22 @@ kafka:wait [CLUSTER]                #  waits until Kafka is ready to use
 kafka:write TOPIC MESSAGE [CLUSTER] #  write message to Kafka topic
 ```
 
-## Development
-
-For normal development, the initial setup is:
-``` sh-session
-$ heroku plugins:link .
-$ npm install
-```
-
-If you add a new command, change a command's args/flags or other metadata, you need to re-run `plugins:link`
-
 ## Install
 
 ``` sh-session
 $ heroku plugins:install heroku-kafka
 ```
+
+## Development
+
+For normal development, the initial setup is:
+``` sh-session
+$ npm install
+$ heroku plugins:link .
+```
+
+If you add a new command, change a command's args/flags or other metadata, you need to re-run `plugins:link`
+
 
 ## Deploying
 


### PR DESCRIPTION
1. Users expect to have installation instructions listed first.
2. If someone wants to contribute, they need to `npm install` before `plugins:link`.