### PR TITLE
Hide kafka jmx and kafka zookeeper for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,21 @@
 A plugin to manage Heroku Kafka.
 
 ```
-kafka:configure TOPIC [CLUSTER]     #  configures a topic in Kafka
-kafka:create TOPIC [CLUSTER]        #  creates a topic in Kafka
-kafka:delete TOPIC [CLUSTER]        #  deletes a topic in Kafka
-kafka:fail [CLUSTER]                #  triggers failure on one node in the cluster
-kafka:info [CLUSTER]                #  shows information about the state of your Kafka cluster
-kafka:list [CLUSTER]                #  lists available Kafka topics
-kafka:tail TOPIC [CLUSTER]          #  tails a topic in Kafka
-kafka:topic TOPIC [CLUSTER]         #  shows information about a topic in Kafka
-kafka:wait [CLUSTER]                #  waits until Kafka is ready to use
-kafka:write TOPIC MESSAGE [CLUSTER] #  write message to Kafka topic
+kafka:fail [CLUSTER]                                   #  triggers failure on one node in the cluster
+kafka:info [CLUSTER]                                   #  display cluster information
+kafka:jmx VALUE [CLUSTER]                              #  enable or disable JMX access to your Kafka cluster
+kafka:topics [CLUSTER]                                 #  lists available Kafka topics
+kafka:topics:compaction TOPIC VALUE [CLUSTER]          #  configures topic compaction in Kafka
+kafka:topics:create TOPIC [CLUSTER]                    #  creates a topic in Kafka
+kafka:topics:destroy TOPIC [CLUSTER]                   #  deletes a topic in Kafka
+kafka:topics:info TOPIC [CLUSTER]                      #  shows information about a topic in Kafka
+kafka:topics:replication-factor TOPIC VALUE [CLUSTER]  #  configures topic replication factor in Kafka
+kafka:topics:retention-time TOPIC VALUE [CLUSTER]      #  configures topic retention time in Kafka
+kafka:topics:tail TOPIC [CLUSTER]                      #  tails a topic in Kafka
+kafka:topics:write TOPIC MESSAGE [CLUSTER]             #  writes a message to a Kafka topic
+kafka:upgrade [CLUSTER]                                #  upgrades kafka broker version
+kafka:wait [CLUSTER]                                   #  waits until Kafka is ready to use
+kafka:zookeeper VALUE [CLUSTER]                        #  enable or disable Zookeeper access to your Kafka cluster
 ```
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ A plugin to manage Heroku Kafka.
 ```
 kafka:fail [CLUSTER]                                   #  triggers failure on one node in the cluster
 kafka:info [CLUSTER]                                   #  display cluster information
-kafka:jmx VALUE [CLUSTER]                              #  enable or disable JMX access to your Kafka cluster
 kafka:topics [CLUSTER]                                 #  lists available Kafka topics
 kafka:topics:compaction TOPIC VALUE [CLUSTER]          #  configures topic compaction in Kafka
 kafka:topics:create TOPIC [CLUSTER]                    #  creates a topic in Kafka
@@ -19,7 +18,6 @@ kafka:topics:tail TOPIC [CLUSTER]                      #  tails a topic in Kafka
 kafka:topics:write TOPIC MESSAGE [CLUSTER]             #  writes a message to a Kafka topic
 kafka:upgrade [CLUSTER]                                #  upgrades kafka broker version
 kafka:wait [CLUSTER]                                   #  waits until Kafka is ready to use
-kafka:zookeeper VALUE [CLUSTER]                        #  enable or disable Zookeeper access to your Kafka cluster
 ```
 
 ## Install

--- a/commands/info.js
+++ b/commands/info.js
@@ -74,6 +74,7 @@ function * run (context, heroku) {
 
 let cmd = {
   topic: 'kafka',
+  description: 'display cluster information',
   needsApp: true,
   needsAuth: true,
   args: [{name: 'CLUSTER', optional: true}],

--- a/commands/jmx.js
+++ b/commands/jmx.js
@@ -33,6 +33,7 @@ function * jmx (context, heroku) {
 }
 
 module.exports = {
+  hidden: true,
   topic: 'kafka',
   command: 'jmx',
   description: 'enable or disable JMX access to your Kafka cluster',

--- a/commands/zookeeper.js
+++ b/commands/zookeeper.js
@@ -37,6 +37,7 @@ function * zookeeper (context, heroku) {
 }
 
 module.exports = {
+  hidden: true,
   topic: 'kafka',
   command: 'zookeeper',
   description: 'enable or disable Zookeeper access to your Kafka cluster',


### PR DESCRIPTION
(Assumes #79 and #80 are in, so includes those commits)