### PR TITLE
Unify and test private plan check

### DIFF
--- a/commands/topics_tail.js
+++ b/commands/topics_tail.js
@@ -6,6 +6,7 @@ const kafka = require('no-kafka')
 
 const debug = require('../lib/debug')
 const clusterConfig = require('../lib/shared').clusterConfig
+const isPrivate = require('../lib/shared').isPrivate
 const deprecated = require('../lib/shared').deprecated
 const withCluster = require('../lib/clusters').withCluster
 
@@ -15,7 +16,7 @@ const MAX_LENGTH = 80
 
 function * tail (context, heroku) {
   yield withCluster(heroku, context.app, context.args.CLUSTER, function * (addon) {
-    if (addon.plan.name.startsWith('heroku-kafka:private-')) {
+    if (isPrivate(addon)) {
       cli.exit(1, '`kafka:topics:tail` is not available in Heroku Private Spaces')
     }
 

--- a/commands/topics_write.js
+++ b/commands/topics_write.js
@@ -6,6 +6,7 @@ const kafka = require('no-kafka')
 
 const debug = require('../lib/debug')
 const clusterConfig = require('../lib/shared').clusterConfig
+const isPrivate = require('../lib/shared').isPrivate
 const deprecated = require('../lib/shared').deprecated
 const withCluster = require('../lib/clusters').withCluster
 
@@ -14,7 +15,7 @@ const IDLE_TIMEOUT = 1000
 
 function * write (context, heroku) {
   yield withCluster(heroku, context.app, context.args.CLUSTER, function * (addon) {
-    if (addon.plan.name.startsWith('heroku-kafka:private-')) {
+    if (isPrivate(addon)) {
       cli.exit(1, '`kafka:topics:write` is not available in Heroku Private Spaces')
     }
 

--- a/commands/zookeeper.js
+++ b/commands/zookeeper.js
@@ -3,6 +3,7 @@
 let cli = require('heroku-cli-util')
 let co = require('co')
 let parseBool = require('../lib/shared').parseBool
+let isPrivate = require('../lib/shared').isPrivate
 let withCluster = require('../lib/clusters').withCluster
 let request = require('../lib/clusters').request
 
@@ -20,7 +21,7 @@ function * zookeeper (context, heroku) {
   }
 
   yield withCluster(heroku, context.app, context.args.CLUSTER, function * (addon) {
-    if (addon.plan.name.indexOf('private-') === -1) {
+    if (!isPrivate(addon)) {
       cli.exit(1, '`kafka:zookeeper` is only available in Heroku Private Spaces')
     }
 

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -23,6 +23,10 @@ function clusterConfig (attachment, config) {
   }
 }
 
+function isPrivate (addon) {
+  return addon.plan.name.indexOf('private-') !== -1
+}
+
 function parseBool (boolStr) {
   switch (boolStr) {
     case 'yes':
@@ -84,8 +88,9 @@ function parseDuration (durationStr) {
 }
 
 module.exports = {
-  clusterConfig: clusterConfig,
-  deprecated: deprecated,
-  parseBool: parseBool,
-  parseDuration: parseDuration
+  clusterConfig,
+  deprecated,
+  parseBool,
+  parseDuration,
+  isPrivate
 }

--- a/test/commands/topics_tail_test.js
+++ b/test/commands/topics_tail_test.js
@@ -52,7 +52,7 @@ describe('kafka:topics:tail', () => {
   }
 
   beforeEach(() => {
-    planName = 'heroku-kafka:beta-3'
+    planName = 'heroku-kafka:beta-standard-2'
     consumer = {
       init: () => { return Promise.resolve() },
       subscribe: (topic, callback) => {}
@@ -70,7 +70,7 @@ describe('kafka:topics:tail', () => {
   })
 
   it('warns and exits with an error if used with a Private Spaces cluster', () => {
-    planName = 'heroku-kafka:private-3'
+    planName = 'heroku-kafka:beta-private-standard-2'
     return expectExit(1, cmd.run({app: 'myapp', args: { TOPIC: 'topic-1' }}))
       .then(() => expect(cli.stdout).to.be.empty)
       .then(() => expect(cli.stderr).to.equal(' ▸    `kafka:topics:tail` is not available in Heroku Private Spaces\n'))

--- a/test/commands/topics_write_test.js
+++ b/test/commands/topics_write_test.js
@@ -56,7 +56,7 @@ describe('kafka:topics:write', () => {
   }
 
   beforeEach(() => {
-    planName = 'heroku-kafka:beta-3'
+    planName = 'heroku-kafka:beta-standard-2'
     producer = {
       init: () => { return Promise.resolve() },
       send: (payload) => { return Promise.resolve() },
@@ -75,7 +75,7 @@ describe('kafka:topics:write', () => {
   })
 
   it('warns and exits with an error if used with a Private Spaces cluster', () => {
-    planName = 'heroku-kafka:private-3'
+    planName = 'heroku-kafka:beta-private-standard-2'
     return expectExit(1, cmd.run({app: 'myapp', args: { TOPIC: 'topic-1' }}))
       .then(() => expect(cli.stdout).to.be.empty)
       .then(() => expect(cli.stderr).to.equal(' ▸    `kafka:topics:write` is not available in Heroku Private Spaces\n'))

--- a/test/commands/zookeeper_test.js
+++ b/test/commands/zookeeper_test.js
@@ -31,7 +31,7 @@ describe('kafka:zookeeper', () => {
   }
 
   beforeEach(() => {
-    planName = 'heroku-kafka:private-3'
+    planName = 'heroku-kafka:beta-private-standard-2'
     kafka = nock('https://kafka-api.heroku.com:443')
     cli.mockConsole()
     cli.exit.mock()
@@ -43,7 +43,7 @@ describe('kafka:zookeeper', () => {
   })
 
   it('warns and exits with an error if used with a non-Private Spaces cluster', () => {
-    planName = 'heroku-kafka:beta-3'
+    planName = 'heroku-kafka:beta-standard-2'
     return expectExit(1, cmd.run({app: 'myapp', args: { VALUE: 'enable' }}))
       .then(() => expect(cli.stdout).to.be.empty)
       .then(() => expect(cli.stderr).to.equal(' ▸    `kafka:zookeeper` is only available in Heroku Private Spaces\n'))

--- a/test/lib/shared_test.js
+++ b/test/lib/shared_test.js
@@ -51,6 +51,32 @@ describe('parseDuration', function () {
   })
 })
 
+describe('isPrivate', function () {
+  let cases = [
+    [ { plan: { name: 'beta-standard-0' } }, false ],
+    [ { plan: { name: 'beta-standard-1' } }, false ],
+    [ { plan: { name: 'beta-standard-2' } }, false ],
+    [ { plan: { name: 'beta-extended-0' } }, false ],
+    [ { plan: { name: 'beta-extended-1' } }, false ],
+    [ { plan: { name: 'beta-extended-2' } }, false ],
+    [ { plan: { name: 'beta-private-standard-0' } }, true ],
+    [ { plan: { name: 'beta-private-standard-1' } }, true ],
+    [ { plan: { name: 'beta-private-standard-2' } }, true ],
+    [ { plan: { name: 'beta-private-extended-0' } }, true ],
+    [ { plan: { name: 'beta-private-extended-1' } }, true ],
+    [ { plan: { name: 'beta-private-extended-2' } }, true ]
+  ]
+  cases.forEach(function (testcase) {
+    let addon = testcase[0]
+    let expected = testcase[1]
+
+    it(`considers '${addon.plan.name}' to${expected ? '' : ' not'} be private'`, function () {
+      let actual = shared.isPrivate(addon)
+      expect(actual).to.equal(expected)
+    })
+  })
+})
+
 describe('parseBool', function () {
   let cases = [
     ['yes', true],


### PR DESCRIPTION
This also fixes the error handling for kafka:write and kafka:tail for private clusters (#84 only fixed part of the problem).

Sorry, I don't know where I got the idea that private plan names started with `private`--I should have checked against the actual plans.