### PR TITLE
Add info regarding Private Spaces constraints to relevant commands

### DIFF
--- a/commands/topics_tail.js
+++ b/commands/topics_tail.js
@@ -62,7 +62,7 @@ function * tail (context, heroku) {
 let cmd = {
   topic: 'kafka',
   command: 'topics:tail',
-  description: 'tails a topic in Kafka',
+  description: '(only outside Private Spaces) tails a topic in Kafka',
   args: [
     { name: 'TOPIC' },
     { name: 'CLUSTER', optional: true }

--- a/commands/topics_write.js
+++ b/commands/topics_write.js
@@ -67,7 +67,7 @@ function * write (context, heroku) {
 let cmd = {
   topic: 'kafka',
   command: 'topics:write',
-  description: 'writes a message to a Kafka topic',
+  description: '(only outside Private Spaces) writes a message to a Kafka topic',
   args: [
     { name: 'TOPIC' },
     { name: 'MESSAGE' },

--- a/commands/zookeeper.js
+++ b/commands/zookeeper.js
@@ -40,13 +40,13 @@ function * zookeeper (context, heroku) {
 module.exports = {
   topic: 'kafka',
   command: 'zookeeper',
-  description: 'enable or disable Zookeeper access to your Kafka cluster',
+  description: '(Private Spaces only) control direct access to Zookeeper of your Kafka cluster',
   args: [
     { name: 'VALUE' },
     { name: 'CLUSTER', optional: true }
   ],
   help: `
-    Enables or disables Zookeeper access to your Kafka cluster. Note that
+    Enables or disables Zookeeper access to your Kafka cluster. Note:
     Zookeeper access is only available in Heroku Private Spaces.
 
     Examples:


### PR DESCRIPTION
New output:

```
maciek@mothra:~/code/aux/heroku-kafka-jsplugin$ heroku help kafka
Usage: heroku kafka [CLUSTER]

display cluster information

 -a, --app APP       # app to run command against
 -r, --remote REMOTE # git remote of app to run command against

Additional commands, type "heroku help COMMAND" for more details:

  ...
  kafka:topics:tail TOPIC [CLUSTER]                      #  (only outside Private Spaces) tails a topic in Kafka
  kafka:topics:write TOPIC MESSAGE [CLUSTER]             #  (only outside Private Spaces) writes a message to a Kafka topic
  ...
  kafka:zookeeper VALUE [CLUSTER]                        #  (Private Spaces only) control direct access to Zookeeper of your Kafka cluster
```

(output for unaffected commands elided)