### PR TITLE
Silence log output from no-kafka

### DIFF
--- a/commands/topics_tail.js
+++ b/commands/topics_tail.js
@@ -30,6 +30,9 @@ function * tail (context, heroku) {
       ssl: {
         clientCert: config.clientCert,
         clientCertKey: config.clientCertKey
+      },
+      logger: {
+        logLevel: 0
       }
     })
     try {

--- a/commands/topics_write.js
+++ b/commands/topics_write.js
@@ -30,6 +30,9 @@ function * write (context, heroku) {
       ssl: {
         clientCert: config.clientCert,
         clientCertKey: config.clientCertKey
+      },
+      logger: {
+        logLevel: 0
       }
     })
     try {


### PR DESCRIPTION
Turns out there is a way to silence the logging output from `no-kafka`--with this `write` produces no output and `tail` only outputs the messages.

Fixes https://github.com/heroku/herokudata/issues/508