### PR TITLE
use data apis instead of client

### DIFF
--- a/commands/info.js
+++ b/commands/info.js
@@ -13,29 +13,61 @@ function configVarsFromName (attachments, name) {
 
 function formatInfo (cluster) {
   let lines = [
-    {name: 'Name', values: [cluster.addon.name]},
-    {name: 'Plan', values: [cluster.addon.plan.name]},
-    {name: 'Status', values: [cluster.cluster.state.message]},
-    {name: 'Version', values: [cluster.cluster.version]},
-    {name: 'Created', values: [cluster.cluster.created_at]}
+    {
+      name: 'Name',
+      values: [cluster.addon.name]
+    },
+    {
+      name: 'Plan',
+      values: [cluster.addon.plan.name]
+    },
+    {
+      name: 'Status',
+      values: [cluster.cluster.state.message]
+    },
+    {
+      name: 'Version',
+      values: [cluster.cluster.version]
+    },
+    {
+      name: 'Created',
+      values: [cluster.cluster.created_at]
+    }
   ]
 
   if (cluster.cluster.robot.is_robot) {
-    lines.push({name: 'Robot', values: ['True']})
-    lines.push({name: 'Robot TTL', values: [cluster.cluster.robot.robot_ttl]})
+    lines.push({
+      name: 'Robot',
+      values: ['True']
+    })
+    lines.push({
+      name: 'Robot TTL', values: [cluster.cluster.robot.robot_ttl]
+    })
   }
 
-  lines.push({name: 'Topics', values: [`${cluster.cluster.topics.length} ${humanize.pluralize(cluster.cluster.topics.length, 'topic')}, see heroku kafka:topics`]})
+  lines.push({
+    name: 'Topics',
+    values: [`${cluster.cluster.topics.length} ${humanize.pluralize(cluster.cluster.topics.length, 'topic')}, see heroku kafka:topics`]
+  })
 
-  lines.push({name: 'Messages', values: [`${humanize.intComma(cluster.cluster.messages_in_per_sec)} ${humanize.pluralize(cluster.cluster.messages_in_per_sec, 'message')}/s`]})
+  lines.push({
+    name: 'Messages',
+    values: [`${humanize.intComma(cluster.cluster.messages_in_per_sec)} ${humanize.pluralize(cluster.cluster.messages_in_per_sec, 'message')}/s`]
+  })
 
-  lines.push({name: 'Traffic', values: [`${humanize.fileSize(cluster.cluster.bytes_in_per_sec)}/s in / ${humanize.fileSize(cluster.cluster.bytes_out_per_sec)}/s out`]})
+  lines.push({
+    name: 'Traffic',
+    values: [`${humanize.fileSize(cluster.cluster.bytes_in_per_sec)}/s in / ${humanize.fileSize(cluster.cluster.bytes_out_per_sec)}/s out`]
+  })
 
   if (cluster.cluster.data_size && cluster.cluster.limits.limit_bytes) {
     let size = cluster.cluster.data_size
     let limit = cluster.cluster.limits.limit_bytes
     let percentage = ((size / limit) * 100.0).toFixed(2)
-    lines.push({name: 'Data Size', values: [`${humanize.fileSize(cluster.cluster.data_size.size)} / ${humanize.fileSize(cluster.cluster.limits.limit_bytes)} (${percentage})`]})
+    lines.push({
+      name: 'Data Size',
+      values: [`${humanize.fileSize(cluster.cluster.data_size.size)} / ${humanize.fileSize(cluster.cluster.limits.limit_bytes)} (${percentage})`]
+    })
   }
 
   lines.push({name: 'Add-on', values: [cli.color.addon(cluster.addon.name)]})

--- a/commands/info.js
+++ b/commands/info.js
@@ -51,7 +51,7 @@ function * run (context, heroku) {
       cluster: heroku.request({
         host: host(addon),
         method: 'get',
-        path: `/client/kafka/v0/clusters/${addon.name}`
+        path: `/data/kafka/v0/clusters/${addon.name}`
       }).catch(err => {
         if (err.statusCode !== 404) throw err
         cli.warn(`${cli.color.addon(addon.name)} is not yet provisioned.\nRun ${cli.color.cmd('heroku kafka:wait')} to wait until the cluster is provisioned.`)

--- a/commands/info.js
+++ b/commands/info.js
@@ -10,16 +10,53 @@ function configVarsFromName (attachments, name) {
     .sort((name) => name !== 'KAFKA_URL')
 }
 
+function format_info (cluster) {
+  let lines = [
+    {name: 'Name', values: [cluster.addon.name]},
+    {name: 'Plan', values: [cluster.addon.plan.name]},
+    {name: 'Status', values: [cluster.cluster.state.message]},
+    {name: 'Version', values: [cluster.cluster.version]},
+    {name: 'Created', values: [cluster.cluster.created_at]},
+  ];
+
+  if (cluster.cluster.robot.is_robot) {
+    lines.push({name: 'Robot', values: ["True"]});
+    lines.push({name: 'Robot TTL', values: [cluster.cluster.robot.robot_ttl]});
+  }
+
+  //TODO: pluralize topics correctly
+  lines.push({name: 'Topics', values: [`${cluster.cluster.topics.length} topics, see heroku kafka:topics`]});
+
+  //TODO: format with commas
+  lines.push({name: 'Messages', values: [`${cluster.cluster.messages_in_per_sec} messages/s`]});
+
+  //TODO: format as human readable sizes
+  lines.push({name: 'Traffic', values: [`${cluster.cluster.bytes_in_per_sec} bytes/s in / ${cluster.cluster.bytes_out_per_sec} bytes/s out`]});
+
+  //TODO: format as human readable size
+  if (cluster.cluster.data_size && cluster.cluster.limits.limit_bytes) {
+    let size = cluster.cluster.data_size;
+    let limit = cluster.cluster.limits.limit_bytes;
+    let percentage = ((size / limit) * 100.0).toFixed(2)
+    lines.push({name: 'Data Size', values: [`${cluster.cluster.data_size.size} / ${cluster.cluster.limits.limit_bytes} (${percentage})`]})
+  }
+
+  lines.push({name: 'Add-on', values: [cli.color.addon(cluster.addon.name)]});
+
+  return lines;
+}
+
 function displayCluster (cluster) {
   cli.styledHeader(cluster.configVars.map(c => cli.color.configVar(c)).join(', '))
-  cluster.cluster.info.push({name: 'Add-on', values: [cli.color.addon(cluster.addon.name)]})
-  let info = cluster.cluster.info.reduce((info, i) => {
+
+  let cluster_info = format_info(cluster);
+  let info = cluster_info.reduce((info, i) => {
     if (i.values.length > 0) {
       info[i.name] = i.values.join(', ')
     }
     return info
   }, {})
-  let keys = cluster.cluster.info.map(i => i.name)
+  let keys = cluster_info.map(i => i.name)
   cli.styledObject(info, keys)
   cli.log()
 }

--- a/commands/info.js
+++ b/commands/info.js
@@ -2,6 +2,7 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
+const humanize = require('humanize-plus')
 
 function configVarsFromName (attachments, name) {
   return attachments
@@ -24,21 +25,17 @@ function formatInfo (cluster) {
     lines.push({name: 'Robot TTL', values: [cluster.cluster.robot.robot_ttl]})
   }
 
-  // TODO: pluralize topics correctly
-  lines.push({name: 'Topics', values: [`${cluster.cluster.topics.length} topics, see heroku kafka:topics`]})
+  lines.push({name: 'Topics', values: [`${cluster.cluster.topics.length} ${humanize.pluralize(cluster.cluster.topics.length, 'topic')}, see heroku kafka:topics`]})
 
-  // TODO: format with commas
-  lines.push({name: 'Messages', values: [`${cluster.cluster.messages_in_per_sec} messages/s`]})
+  lines.push({name: 'Messages', values: [`${humanize.intComma(cluster.cluster.messages_in_per_sec)} ${humanize.pluralize(cluster.cluster.messages_in_per_sec, 'message')}/s`]})
 
-  // TODO: format as human readable sizes
-  lines.push({name: 'Traffic', values: [`${cluster.cluster.bytes_in_per_sec} bytes/s in / ${cluster.cluster.bytes_out_per_sec} bytes/s out`]})
+  lines.push({name: 'Traffic', values: [`${humanize.fileSize(cluster.cluster.bytes_in_per_sec)}/s in / ${humanize.fileSize(cluster.cluster.bytes_out_per_sec)}/s out`]})
 
-  // TODO: format as human readable size
   if (cluster.cluster.data_size && cluster.cluster.limits.limit_bytes) {
     let size = cluster.cluster.data_size
     let limit = cluster.cluster.limits.limit_bytes
     let percentage = ((size / limit) * 100.0).toFixed(2)
-    lines.push({name: 'Data Size', values: [`${cluster.cluster.data_size.size} / ${cluster.cluster.limits.limit_bytes} (${percentage})`]})
+    lines.push({name: 'Data Size', values: [`${humanize.fileSize(cluster.cluster.data_size.size)} / ${humanize.fileSize(cluster.cluster.limits.limit_bytes)} (${percentage})`]})
   }
 
   lines.push({name: 'Add-on', values: [cli.color.addon(cluster.addon.name)]})

--- a/commands/info.js
+++ b/commands/info.js
@@ -10,53 +10,54 @@ function configVarsFromName (attachments, name) {
     .sort((name) => name !== 'KAFKA_URL')
 }
 
-function format_info (cluster) {
+function formatInfo (cluster) {
   let lines = [
     {name: 'Name', values: [cluster.addon.name]},
     {name: 'Plan', values: [cluster.addon.plan.name]},
     {name: 'Status', values: [cluster.cluster.state.message]},
     {name: 'Version', values: [cluster.cluster.version]},
-    {name: 'Created', values: [cluster.cluster.created_at]},
-  ];
+    {name: 'Created', values: [cluster.cluster.created_at]}
+  ]
 
   if (cluster.cluster.robot.is_robot) {
-    lines.push({name: 'Robot', values: ["True"]});
-    lines.push({name: 'Robot TTL', values: [cluster.cluster.robot.robot_ttl]});
+    lines.push({name: 'Robot', values: ['True']})
+    lines.push({name: 'Robot TTL', values: [cluster.cluster.robot.robot_ttl]})
   }
 
-  //TODO: pluralize topics correctly
-  lines.push({name: 'Topics', values: [`${cluster.cluster.topics.length} topics, see heroku kafka:topics`]});
+  // TODO: pluralize topics correctly
+  lines.push({name: 'Topics', values: [`${cluster.cluster.topics.length} topics, see heroku kafka:topics`]})
 
-  //TODO: format with commas
-  lines.push({name: 'Messages', values: [`${cluster.cluster.messages_in_per_sec} messages/s`]});
+  // TODO: format with commas
+  lines.push({name: 'Messages', values: [`${cluster.cluster.messages_in_per_sec} messages/s`]})
 
-  //TODO: format as human readable sizes
-  lines.push({name: 'Traffic', values: [`${cluster.cluster.bytes_in_per_sec} bytes/s in / ${cluster.cluster.bytes_out_per_sec} bytes/s out`]});
+  // TODO: format as human readable sizes
+  lines.push({name: 'Traffic', values: [`${cluster.cluster.bytes_in_per_sec} bytes/s in / ${cluster.cluster.bytes_out_per_sec} bytes/s out`]})
 
-  //TODO: format as human readable size
+  // TODO: format as human readable size
   if (cluster.cluster.data_size && cluster.cluster.limits.limit_bytes) {
-    let size = cluster.cluster.data_size;
-    let limit = cluster.cluster.limits.limit_bytes;
+    let size = cluster.cluster.data_size
+    let limit = cluster.cluster.limits.limit_bytes
     let percentage = ((size / limit) * 100.0).toFixed(2)
     lines.push({name: 'Data Size', values: [`${cluster.cluster.data_size.size} / ${cluster.cluster.limits.limit_bytes} (${percentage})`]})
   }
 
-  lines.push({name: 'Add-on', values: [cli.color.addon(cluster.addon.name)]});
+  lines.push({name: 'Add-on', values: [cli.color.addon(cluster.addon.name)]})
 
-  return lines;
+  return lines
 }
 
 function displayCluster (cluster) {
   cli.styledHeader(cluster.configVars.map(c => cli.color.configVar(c)).join(', '))
 
-  let cluster_info = format_info(cluster);
-  let info = cluster_info.reduce((info, i) => {
+  let clusterInfo = formatInfo(cluster)
+  let info = clusterInfo.reduce((info, i) => {
     if (i.values.length > 0) {
       info[i.name] = i.values.join(', ')
     }
     return info
   }, {})
-  let keys = cluster_info.map(i => i.name)
+  let keys = clusterInfo.map(i => i.name)
+
   cli.styledObject(info, keys)
   cli.log()
 }

--- a/commands/topics.js
+++ b/commands/topics.js
@@ -2,6 +2,7 @@
 
 let cli = require('heroku-cli-util')
 let co = require('co')
+let humanize = require('humanize-plus')
 let deprecated = require('../lib/shared').deprecated
 let withCluster = require('../lib/clusters').withCluster
 let request = require('../lib/clusters').request
@@ -18,10 +19,8 @@ function * listTopics (context, heroku) {
     let topicData = filtered.map((t) => {
       return {
         name: t.name,
-        // TODO: format as human readable
-        messages: `${t.messages_in_per_second}/sec`,
-        // TODO: format as human readable
-        bytes: `${t.bytes_in_per_second} bytes/sec`
+        messages: `${humanize.intComma(t.messages_in_per_second)}/sec`,
+        bytes: `${humanize.fileSize(t.bytes_in_per_second)}/sec`
       }
     })
     cli.log()

--- a/commands/topics.js
+++ b/commands/topics.js
@@ -11,11 +11,19 @@ const VERSION = 'v0'
 function * listTopics (context, heroku) {
   yield withCluster(heroku, context.app, context.args.CLUSTER, function * (addon) {
     let topics = yield request(heroku, {
-      path: `/client/kafka/${VERSION}/clusters/${addon.name}/topics`
+      path: `/data/kafka/${VERSION}/clusters/${addon.name}/topics`
     })
-
     cli.styledHeader('Kafka Topics on ' + (topics.attachment_name || 'HEROKU_KAFKA'))
-    let topicData = topics.topics.filter((t) => t.name !== '__consumer_offsets')
+    let filtered = topics.topics.filter((t) => t.name !== '__consumer_offsets')
+    let topicData = filtered.map((t) => {
+      return {
+        name: t.name,
+        //TODO: format as human readable
+        messages: `${t.messages_in_per_second} messages/s`,
+        //TODO: format as human readable
+        bytes: `${t.bytes_in_per_second} bytes/s`,
+      }
+    });
     cli.log()
     if (topicData.length === 0) {
       cli.log('No topics found on this Kafka cluster.')

--- a/commands/topics.js
+++ b/commands/topics.js
@@ -18,12 +18,12 @@ function * listTopics (context, heroku) {
     let topicData = filtered.map((t) => {
       return {
         name: t.name,
-        //TODO: format as human readable
-        messages: `${t.messages_in_per_second} messages/s`,
-        //TODO: format as human readable
-        bytes: `${t.bytes_in_per_second} bytes/s`,
+        // TODO: format as human readable
+        messages: `${t.messages_in_per_second}/sec`,
+        // TODO: format as human readable
+        bytes: `${t.bytes_in_per_second} bytes/sec`
       }
-    });
+    })
     cli.log()
     if (topicData.length === 0) {
       cli.log('No topics found on this Kafka cluster.')

--- a/commands/topics_compaction.js
+++ b/commands/topics_compaction.js
@@ -29,7 +29,7 @@ function * compaction (context, heroku) {
             compaction: enabled
           }
         },
-        path: `/client/kafka/${VERSION}/clusters/${addon.name}/topics/${topicName}`
+        path: `/data/kafka/${VERSION}/clusters/${addon.name}/topics/${topicName}`
       })
     }))
     cli.log(`Use \`heroku kafka:topics:info ${context.args.TOPIC}\` to monitor your topic.`)

--- a/commands/topics_create.js
+++ b/commands/topics_create.js
@@ -48,7 +48,7 @@ function * createTopic (context, heroku) {
             compaction: flags['compaction'] || false
           }
         },
-        path: `/client/kafka/${VERSION}/clusters/${addon.name}/topics`
+        path: `/data/kafka/${VERSION}/clusters/${addon.name}/topics`
       })
     }))
 

--- a/commands/topics_destroy.js
+++ b/commands/topics_destroy.js
@@ -18,7 +18,7 @@ function * destroyTopic (context, heroku) {
       return yield request(heroku, {
         method: 'DELETE',
         body: {
-          topic_name: { name: topicName }
+          topic_name: topicName
         },
         path: `/data/kafka/${VERSION}/clusters/${addon.name}/topics/${topicName}`
       })

--- a/commands/topics_destroy.js
+++ b/commands/topics_destroy.js
@@ -18,9 +18,9 @@ function * destroyTopic (context, heroku) {
       return yield request(heroku, {
         method: 'DELETE',
         body: {
-          topic: { name: topicName }
+          topic_name: { name: topicName }
         },
-        path: `/client/kafka/${VERSION}/clusters/${addon.name}/topics/${topicName}`
+        path: `/data/kafka/${VERSION}/clusters/${addon.name}/topics/${topicName}`
       })
     }))
 

--- a/commands/topics_info.js
+++ b/commands/topics_info.js
@@ -26,7 +26,6 @@ function topicInfo (topic) {
   let lines = [
     {name: 'Producers', values: [`${humanize.intComma(topic.messages_in_per_second)} ${humanize.pluralize(topic.messages_in_per_second, 'message')}/second (${humanize.fileSize(topic.bytes_in_per_second)}/second) total`]},
     {name: 'Consumers', values: [`${humanize.fileSize(topic.bytes_out_per_second)}/second total`]},
-    // TODO: pluralize
     {name: 'Partitions', values: [`${topic.partitions} ${humanize.pluralize(topic.partitions, 'partition')}`]},
     {name: 'Replication Factor', values: [`${topic.replication_factor} (recommend > 1)`]}
   ]

--- a/commands/topics_info.js
+++ b/commands/topics_info.js
@@ -24,17 +24,38 @@ function retention (retentionTimeMs) {
 
 function topicInfo (topic) {
   let lines = [
-    {name: 'Producers', values: [`${humanize.intComma(topic.messages_in_per_second)} ${humanize.pluralize(topic.messages_in_per_second, 'message')}/second (${humanize.fileSize(topic.bytes_in_per_second)}/second) total`]},
-    {name: 'Consumers', values: [`${humanize.fileSize(topic.bytes_out_per_second)}/second total`]},
-    {name: 'Partitions', values: [`${topic.partitions} ${humanize.pluralize(topic.partitions, 'partition')}`]},
-    {name: 'Replication Factor', values: [`${topic.replication_factor} (recommend > 1)`]}
+    {
+      name: 'Producers',
+      values: [`${humanize.intComma(topic.messages_in_per_second)} ${humanize.pluralize(topic.messages_in_per_second, 'message')}/second (${humanize.fileSize(topic.bytes_in_per_second)}/second) total`]
+    },
+    {
+      name: 'Consumers',
+      values: [`${humanize.fileSize(topic.bytes_out_per_second)}/second total`]
+    },
+    {
+      name: 'Partitions',
+      values: [`${topic.partitions} ${humanize.pluralize(topic.partitions, 'partition')}`]
+    },
+    {
+      name: 'Replication Factor',
+      values: [`${topic.replication_factor} (recommend > 1)`]
+    }
   ]
 
   if (topic.compaction_enabled) {
-    lines.push({name: 'Compaction', values: [`Compaction is enabled for ${topic.name}`]})
+    lines.push({
+      name: 'Compaction',
+      values: [`Compaction is enabled for ${topic.name}`]
+    })
   } else {
-    lines.push({name: 'Compaction', values: [`Compaction is disabled for ${topic.name}`]})
-    lines.push({name: 'Retention', values: [retention(topic.retention_time_ms)]})
+    lines.push({
+      name: 'Compaction',
+      values: [`Compaction is disabled for ${topic.name}`]
+    })
+    lines.push({
+      name: 'Retention',
+      values: [retention(topic.retention_time_ms)]
+    })
   }
 
   return lines

--- a/commands/topics_info.js
+++ b/commands/topics_info.js
@@ -13,32 +13,32 @@ const TWO_DAYS_IN_MS = 172800000
 
 
 
-function retention (retention_time_ms) {
-  if (retention_time_ms < ONE_HOUR_IN_MS) {
-    return `${Math.round(retention_time_ms / 1000.0)} seconds`
-  } else if (retention_time_ms < TWO_DAYS_IN_MS) {
-    return `${Math.round(retention_time_ms / ONE_HOUR_IN_MS)} hours`
+function retention (retentionTimeMs) {
+  if (retentionTimeMs < ONE_HOUR_IN_MS) {
+    return `${Math.round(retentionTimeMs / 1000.0)} seconds`
+  } else if (retentionTimeMs < TWO_DAYS_IN_MS) {
+    return `${Math.round(retentionTimeMs / ONE_HOUR_IN_MS)} hours`
   } else {
-    return `${Math.round(retention_time_ms / TWENTY_FOUR_HOURS_IN_MS)} days`
+    return `${Math.round(retentionTimeMs / TWENTY_FOUR_HOURS_IN_MS)} days`
   }
 }
 
-function topicInfo(topic) {
+function topicInfo (topic) {
   let lines = [
-    //TODO: format as human
+    // TODO: format as human
     {name: 'Producers', values: [`${topic.messages_in_per_second} messages/second (${topic.bytes_in_per_second} bytes/second) total`]},
-    //TODO: format as human
-    {name: 'Consumers', values: [`${topic.bytes_out_per_second} total`]},
-    //TODO: pluralize
+    // TODO: format as human
+    {name: 'Consumers', values: [`${topic.bytes_out_per_second} bytes/second total`]},
+    // TODO: pluralize
     {name: 'Partitions', values: [`${topic.partitions} partitions`]},
-    {name: 'Replication Factor', values: [`${topic.replication_factor} (reccomend > 1)`]},
-  ];
+    {name: 'Replication Factor', values: [`${topic.replication_factor} (recommend > 1)`]}
+  ]
 
   if (topic.compaction_enabled) {
-    lines.push({name: 'Compaction', values: [`Compaction is enabled for ${topic.name}`]});
+    lines.push({name: 'Compaction', values: [`Compaction is enabled for ${topic.name}`]})
   } else {
-    lines.push({name: 'Compaction', values: [`Compaction is disabled for ${topic.name}`]});
-    lines.push({name: 'Retention', values: [retention(topic.retention_time_ms)]});
+    lines.push({name: 'Compaction', values: [`Compaction is disabled for ${topic.name}`]})
+    lines.push({name: 'Retention', values: [retention(topic.retention_time_ms)]})
   }
 
   return lines
@@ -52,11 +52,11 @@ function * kafkaTopic (context, heroku) {
       path: `/data/kafka/${VERSION}/clusters/${addon.name}/topics`
     })
 
-    let forTopic = info.topics.filter((t) => t.name == topic);
+    let forTopic = info.topics.filter((t) => t.name === topic)
 
     if (forTopic.length === 0) {
       cli.error(`topic not found ${topic}`)
-      cli.exit(1);
+      cli.exit(1)
     }
 
     cli.styledHeader((info.attachment_name || 'HEROKU_KAFKA') + ' :: ' + topic)

--- a/commands/topics_info.js
+++ b/commands/topics_info.js
@@ -8,11 +8,9 @@ let withCluster = require('../lib/clusters').withCluster
 let request = require('../lib/clusters').request
 
 const VERSION = 'v0'
-const ONE_HOUR_IN_MS = 3600000
-const TWENTY_FOUR_HOURS_IN_MS = 86400000
-const TWO_DAYS_IN_MS = 172800000
-
-
+const ONE_HOUR_IN_MS = 60 * 60 * 1000
+const TWENTY_FOUR_HOURS_IN_MS = ONE_HOUR_IN_MS * 24
+const TWO_DAYS_IN_MS = TWENTY_FOUR_HOURS_IN_MS * 2
 
 function retention (retentionTimeMs) {
   if (retentionTimeMs < ONE_HOUR_IN_MS) {

--- a/commands/topics_info.js
+++ b/commands/topics_info.js
@@ -2,6 +2,7 @@
 
 let cli = require('heroku-cli-util')
 let co = require('co')
+let humanize = require('humanize-plus')
 let deprecated = require('../lib/shared').deprecated
 let withCluster = require('../lib/clusters').withCluster
 let request = require('../lib/clusters').request
@@ -25,12 +26,10 @@ function retention (retentionTimeMs) {
 
 function topicInfo (topic) {
   let lines = [
-    // TODO: format as human
-    {name: 'Producers', values: [`${topic.messages_in_per_second} messages/second (${topic.bytes_in_per_second} bytes/second) total`]},
-    // TODO: format as human
-    {name: 'Consumers', values: [`${topic.bytes_out_per_second} bytes/second total`]},
+    {name: 'Producers', values: [`${humanize.intComma(topic.messages_in_per_second)} ${humanize.pluralize(topic.messages_in_per_second, 'message')}/second (${humanize.fileSize(topic.bytes_in_per_second)}/second) total`]},
+    {name: 'Consumers', values: [`${humanize.fileSize(topic.bytes_out_per_second)}/second total`]},
     // TODO: pluralize
-    {name: 'Partitions', values: [`${topic.partitions} partitions`]},
+    {name: 'Partitions', values: [`${topic.partitions} ${humanize.pluralize(topic.partitions, 'partition')}`]},
     {name: 'Replication Factor', values: [`${topic.replication_factor} (recommend > 1)`]}
   ]
 

--- a/commands/topics_replication_factor.js
+++ b/commands/topics_replication_factor.js
@@ -23,7 +23,7 @@ function * replicationFactor (context, heroku) {
             replication_factor: context.args.VALUE
           }
         },
-        path: `/client/kafka/${VERSION}/clusters/${addon.name}/topics/${topicName}`
+        path: `/data/kafka/${VERSION}/clusters/${addon.name}/topics/${topicName}`
       })
     }))
     cli.log(`Use \`heroku kafka:topics:info ${context.args.TOPIC}\` to monitor your topic.`)

--- a/commands/topics_retention_time.js
+++ b/commands/topics_retention_time.js
@@ -29,7 +29,7 @@ function * retentionTime (context, heroku) {
             retention_time_ms: parsed
           }
         },
-        path: `/client/kafka/${VERSION}/clusters/${addon.name}/topics/${topicName}`
+        path: `/data/kafka/${VERSION}/clusters/${addon.name}/topics/${topicName}`
       })
     }))
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "debug": "2.2.0",
     "heroku-cli-addons": "1.0.5",
     "heroku-cli-util": "6.0.15",
+    "humanize-plus": "^1.8.2",
     "lodash.uniqby": "4.6.1",
     "no-kafka": "github:hunterloftis/kafka",
     "node-spinner": "0.0.4"

--- a/test/commands/info_test.js
+++ b/test/commands/info_test.js
@@ -32,7 +32,7 @@ describe('kafka:info', () => {
   let api, kafka
 
   let infoUrl = (cluster) => {
-    return `/client/kafka/v0/clusters/${cluster}`
+    return `/data/kafka/v0/clusters/${cluster}`
   }
 
   beforeEach(() => {
@@ -70,17 +70,26 @@ describe('kafka:info', () => {
       {id: 2, name: 'kafka-2', addon_service: addonService, plan}
     ]
     let clusterA = {
-      info: [
-        {name: 'Plan', values: ['Beta-3']},
-        {name: 'Empty', values: []}
-      ],
-      addon: { name: 'kafka-1' }
+      addon: { name: 'kafka-1' },
+      state: { message: 'available' },
+      robot: { is_robot: false },
+      topics: ['messages'],
+      messages_in_per_sec: 0,
+      bytes_in_per_sec: 0,
+      bytes_out_per_sec: 0,
+      version: ['0.10.0.0'],
+      created_at: '2016-11-14T14:26:20.245+00:00'
     }
     let clusterB = {
-      info: [
-        {name: 'Plan', values: ['Beta-3']}
-      ],
-      addon: { name: 'kafka-2' }
+      addon: { name: 'kafka-2' },
+      state: { message: 'available' },
+      robot: { is_robot: false },
+      topics: ['messages'],
+      messages_in_per_sec: 0,
+      bytes_in_per_sec: 0,
+      bytes_out_per_sec: 0,
+      version: ['0.10.0.0'],
+      created_at: '2016-11-14T14:26:20.245+00:00'
     }
 
     it('shows kafka info', () => {
@@ -94,12 +103,26 @@ describe('kafka:info', () => {
       return cmd.run({app: 'myapp', args: {}})
         .then(() => expect(cli.stderr).to.be.empty)
         .then(() => expect(cli.stdout).to.equal(`=== KAFKA_URL, HEROKU_KAFKA_COBALT_URL
-Plan:   Beta-3
-Add-on: kafka-1
+Name:     kafka-1
+Plan:     heroku-kafka:beta-3
+Status:   available
+Version:  0.10.0.0
+Created:  2016-11-14T14:26:20.245+00:00
+Topics:   1 topics, see heroku kafka:topics
+Messages: 0 messages/s
+Traffic:  0 bytes/s in / 0 bytes/s out
+Add-on:   kafka-1
 
 === HEROKU_KAFKA_PURPLE_URL
-Plan:   Beta-3
-Add-on: kafka-2
+Name:     kafka-2
+Plan:     heroku-kafka:beta-3
+Status:   available
+Version:  0.10.0.0
+Created:  2016-11-14T14:26:20.245+00:00
+Topics:   1 topics, see heroku kafka:topics
+Messages: 0 messages/s
+Traffic:  0 bytes/s in / 0 bytes/s out
+Add-on:   kafka-2
 
 `))
     })
@@ -115,8 +138,15 @@ Add-on: kafka-2
       return cmd.run({app: 'myapp', args: {CLUSTER: 'kafka-2'}})
         .then(() => expect(cli.stderr).to.be.empty)
         .then(() => expect(cli.stdout).to.equal(`=== HEROKU_KAFKA_PURPLE_URL
-Plan:   Beta-3
-Add-on: kafka-2
+Name:     kafka-2
+Plan:     heroku-kafka:beta-3
+Status:   available
+Version:  0.10.0.0
+Created:  2016-11-14T14:26:20.245+00:00
+Topics:   1 topics, see heroku kafka:topics
+Messages: 0 messages/s
+Traffic:  0 bytes/s in / 0 bytes/s out
+Add-on:   kafka-2
 
 `))
     })
@@ -131,8 +161,15 @@ Add-on: kafka-2
 
       return cmd.run({app: 'myapp', args: {}})
         .then(() => expect(cli.stdout).to.equal(`=== HEROKU_KAFKA_PURPLE_URL
-Plan:   Beta-3
-Add-on: kafka-2
+Name:     kafka-2
+Plan:     heroku-kafka:beta-3
+Status:   available
+Version:  0.10.0.0
+Created:  2016-11-14T14:26:20.245+00:00
+Topics:   1 topics, see heroku kafka:topics
+Messages: 0 messages/s
+Traffic:  0 bytes/s in / 0 bytes/s out
+Add-on:   kafka-2
 
 `))
         .then(() => expect(cli.stderr).to.equal(` ▸    kafka-1 is not yet provisioned.

--- a/test/commands/info_test.js
+++ b/test/commands/info_test.js
@@ -108,7 +108,7 @@ Plan:     heroku-kafka:beta-3
 Status:   available
 Version:  0.10.0.0
 Created:  2016-11-14T14:26:20.245+00:00
-Topics:   1 topics, see heroku kafka:topics
+Topics:   1 topic, see heroku kafka:topics
 Messages: 0 messages/s
 Traffic:  0 bytes/s in / 0 bytes/s out
 Add-on:   kafka-1
@@ -119,7 +119,7 @@ Plan:     heroku-kafka:beta-3
 Status:   available
 Version:  0.10.0.0
 Created:  2016-11-14T14:26:20.245+00:00
-Topics:   1 topics, see heroku kafka:topics
+Topics:   1 topic, see heroku kafka:topics
 Messages: 0 messages/s
 Traffic:  0 bytes/s in / 0 bytes/s out
 Add-on:   kafka-2
@@ -143,7 +143,7 @@ Plan:     heroku-kafka:beta-3
 Status:   available
 Version:  0.10.0.0
 Created:  2016-11-14T14:26:20.245+00:00
-Topics:   1 topics, see heroku kafka:topics
+Topics:   1 topic, see heroku kafka:topics
 Messages: 0 messages/s
 Traffic:  0 bytes/s in / 0 bytes/s out
 Add-on:   kafka-2
@@ -166,7 +166,7 @@ Plan:     heroku-kafka:beta-3
 Status:   available
 Version:  0.10.0.0
 Created:  2016-11-14T14:26:20.245+00:00
-Topics:   1 topics, see heroku kafka:topics
+Topics:   1 topic, see heroku kafka:topics
 Messages: 0 messages/s
 Traffic:  0 bytes/s in / 0 bytes/s out
 Add-on:   kafka-2

--- a/test/commands/topics_compaction_test.js
+++ b/test/commands/topics_compaction_test.js
@@ -26,7 +26,7 @@ describe('kafka:topics:compaction', () => {
   let kafka
 
   let topicConfigUrl = (cluster, topic) => {
-    return `/client/kafka/v0/clusters/${cluster}/topics/${topic}`
+    return `/data/kafka/v0/clusters/${cluster}/topics/${topic}`
   }
 
   beforeEach(() => {

--- a/test/commands/topics_create_test.js
+++ b/test/commands/topics_create_test.js
@@ -37,7 +37,7 @@ describe('kafka:topics:create', () => {
   let kafka
 
   let createUrl = (cluster) => {
-    return `/client/kafka/v0/clusters/${cluster}/topics`
+    return `/data/kafka/v0/clusters/${cluster}/topics`
   }
 
   beforeEach(() => {

--- a/test/commands/topics_destroy_test.js
+++ b/test/commands/topics_destroy_test.js
@@ -31,12 +31,12 @@ const cmd = proxyquire('../../commands/topics_destroy', {
   }
 }).cmd
 
-describe('kafka:topics:create', () => {
+describe('kafka:topics:destroy', () => {
   let confirm
   let kafka
 
   let deleteUrl = (cluster, topic) => {
-    return `/client/kafka/v0/clusters/${cluster}/topics/${topic}`
+    return `/data/kafka/v0/clusters/${cluster}/topics/${topic}`
   }
 
   beforeEach(() => {
@@ -74,7 +74,7 @@ describe('kafka:topics:create', () => {
   })
 
   it('deletes the topic', () => {
-    kafka.delete(deleteUrl('kafka-1', 'topic-1'), { topic: { name: 'topic-1' } })
+    kafka.delete(deleteUrl('kafka-1', 'topic-1'), { topic_name: 'topic-1' })
          .reply(200)
 
     return cmd.run({app: 'myapp',

--- a/test/commands/topics_info_test.js
+++ b/test/commands/topics_info_test.js
@@ -24,8 +24,8 @@ const cmd = proxyquire('../../commands/topics_info', {
 describe('kafka:topics:info', () => {
   let kafka
 
-  let topicsUrl = (cluster, topic) => {
-    return `/client/kafka/v0/clusters/${cluster}/topics/${topic}`
+  let topicsUrl = (cluster) => {
+    return `/data/kafka/v0/clusters/${cluster}/topics`
   }
 
   beforeEach(() => {
@@ -40,24 +40,27 @@ describe('kafka:topics:info', () => {
   })
 
   it('displays the topic info', () => {
-    kafka.get(topicsUrl('kafka-1', 'topic-1')).reply(200, {
+    kafka.get(topicsUrl('kafka-1')).reply(200, {
       attachment_name: 'HEROKU_KAFKA_BLUE_URL',
-      topic: 'topic-1',
-      info: [
-        { name: 'Producers', values: [ '0.0 messages/second (0 Bytes/second) total' ] },
-        { name: 'Consumers', values: [ '0 Bytes/second total' ] },
-        { name: 'Partitions', values: [ '3 partitions' ] },
-        { name: 'Replication Factor', values: [ '3 (recommend > 1)' ] },
-        { name: 'Compaction', values: [ 'Compaction is disabled for topic-1' ] },
-        { name: 'Retention', values: [ '24 hours' ] }
+      topics: [
+        {
+          name: 'topic-1',
+          messages_in_per_second: 0,
+          bytes_in_per_second: 0,
+          bytes_out_per_second: 0,
+          replication_factor: 3,
+          partitions: 3,
+          compaction_enabled: false,
+          retention_time_ms: 86400000
+        }
       ]
     })
 
     return cmd.run({app: 'myapp', args: { TOPIC: 'topic-1' }})
       .then(() => expect(cli.stdout).to.equal(`=== HEROKU_KAFKA_BLUE_URL :: topic-1
 
-Producers:          0.0 messages/second (0 Bytes/second) total
-Consumers:          0 Bytes/second total
+Producers:          0 messages/second (0 bytes/second) total
+Consumers:          0 bytes/second total
 Partitions:         3 partitions
 Replication Factor: 3 (recommend > 1)
 Compaction:         Compaction is disabled for topic-1

--- a/test/commands/topics_replication_factor_test.js
+++ b/test/commands/topics_replication_factor_test.js
@@ -25,7 +25,7 @@ describe('kafka:topics:replication-factor', () => {
   let kafka
 
   let topicConfigUrl = (cluster, topic) => {
-    return `/client/kafka/v0/clusters/${cluster}/topics/${topic}`
+    return `/data/kafka/v0/clusters/${cluster}/topics/${topic}`
   }
 
   beforeEach(() => {

--- a/test/commands/topics_retention_time_test.js
+++ b/test/commands/topics_retention_time_test.js
@@ -26,7 +26,7 @@ describe('kafka:topics:retention-time', () => {
   let kafka
 
   let topicConfigUrl = (cluster, topic) => {
-    return `/client/kafka/v0/clusters/${cluster}/topics/${topic}`
+    return `/data/kafka/v0/clusters/${cluster}/topics/${topic}`
   }
 
   beforeEach(() => {

--- a/test/commands/topics_test.js
+++ b/test/commands/topics_test.js
@@ -25,7 +25,7 @@ describe('kafka:topics', () => {
   let kafka
 
   let topicsUrl = (cluster) => {
-    return `/client/kafka/v0/clusters/${cluster}/topics`
+    return `/data/kafka/v0/clusters/${cluster}/topics`
   }
 
   beforeEach(() => {
@@ -59,7 +59,7 @@ Use heroku kafka:topics:create to create a topic.
       kafka.get(topicsUrl('kafka-1')).reply(200, {
         attachment_name: 'HEROKU_KAFKA_BLUE_URL',
         topics: [
-          { name: '__consumer_offsets', messages: '9.0/sec', bytes: '2 bytes/sec' }
+          { name: '__consumer_offsets', messages_in_per_second: 9.0, bytes_in_per_second: 2 }
         ]
       })
 
@@ -78,8 +78,8 @@ Use heroku kafka:topics:create to create a topic.
       kafka.get(topicsUrl('kafka-1')).reply(200, {
         attachment_name: 'HEROKU_KAFKA_BLUE_URL',
         topics: [
-          { name: 'topic-1', messages: '10.0/sec', bytes: '0 bytes/sec' },
-          { name: 'topic-2', messages: '12.0/sec', bytes: '3 bytes/sec' }
+          { name: 'topic-1', messages_in_per_second: 10.0, bytes_in_per_second: 0 },
+          { name: 'topic-2', messages_in_per_second: 12.0, bytes_in_per_second: 3 }
         ]
       })
 
@@ -88,8 +88,8 @@ Use heroku kafka:topics:create to create a topic.
 
 Name     Messages  Traffic
 ───────  ────────  ───────────
-topic-1  10.0/sec  0 bytes/sec
-topic-2  12.0/sec  3 bytes/sec
+topic-1  10/sec    0 bytes/sec
+topic-2  12/sec    3 bytes/sec
 `))
         .then(() => expect(cli.stderr).to.be.empty)
     })
@@ -98,9 +98,9 @@ topic-2  12.0/sec  3 bytes/sec
       kafka.get(topicsUrl('kafka-1')).reply(200, {
         attachment_name: 'HEROKU_KAFKA_BLUE_URL',
         topics: [
-          { name: '__consumer_offsets', messages: '9.0/sec', bytes: '2 bytes/sec' },
-          { name: 'topic-1', messages: '10.0/sec', bytes: '0 bytes/sec' },
-          { name: 'topic-2', messages: '12.0/sec', bytes: '3 bytes/sec' }
+          { name: '__consumer_offsets', messages_in_per_second: '9.0', bytes: '2' },
+          { name: 'topic-1', messages_in_per_second: 10.0, bytes_in_per_second: 0 },
+          { name: 'topic-2', messages_in_per_second: 12.0, bytes_in_per_second: 3 }
         ]
       })
 
@@ -109,8 +109,8 @@ topic-2  12.0/sec  3 bytes/sec
 
 Name     Messages  Traffic
 ───────  ────────  ───────────
-topic-1  10.0/sec  0 bytes/sec
-topic-2  12.0/sec  3 bytes/sec
+topic-1  10/sec    0 bytes/sec
+topic-2  12/sec    3 bytes/sec
 `))
         .then(() => expect(cli.stderr).to.be.empty)
     })


### PR DESCRIPTION
#### What does this PR do?

Implements the Kafka cli relying on `/data` apis, to remove duplication of work on the shogun side.
See https://github.com/heroku/shogun/pull/5662 for a prerequisite shogun PR.

#### How has this been tested?

Staging

#### Any relevant links (support ticket or trello card) ?

- email thread: https://groups.google.com/a/heroku.com/forum/#!topic/dod-kcz/DJj9kfNQjNg
- trello card: https://trello.com/c/lcgX8ZrW/472-eliminate-client-data-endpoints-mismatches-and-add-tests