### PR TITLE
Preauth anything that talks to the heroku-kafka API

### DIFF
--- a/commands/configure.js
+++ b/commands/configure.js
@@ -62,5 +62,5 @@ module.exports = {
     { name: 'no-compaction', description: 'disables compaction on the topic if passed', hasValue: false },
     { name: 'replication-factor', description: 'number of replicas each partition in the topic has', hasValue: true }
   ],
-  run: cli.command(co.wrap(configureTopic))
+  run: cli.command({preauth: true}, co.wrap(configureTopic))
 }

--- a/commands/credentials_rotate.js
+++ b/commands/credentials_rotate.js
@@ -41,5 +41,5 @@ module.exports = {
       hasValue: false,
       required: true }
   ],
-  run: cli.command(co.wrap(credentialsRotate))
+  run: cli.command({preauth: true}, co.wrap(credentialsRotate))
 }

--- a/commands/fail.js
+++ b/commands/fail.js
@@ -56,5 +56,5 @@ module.exports = {
       hasValue: true,
       required: false }
   ],
-  run: cli.command(co.wrap(fail))
+  run: cli.command({preauth: true}, co.wrap(fail))
 }

--- a/commands/jmx.js
+++ b/commands/jmx.js
@@ -56,5 +56,5 @@ module.exports = {
 `,
   needsApp: true,
   needsAuth: true,
-  run: cli.command(co.wrap(jmx))
+  run: cli.command({preauth: true}, co.wrap(jmx))
 }

--- a/commands/topics.js
+++ b/commands/topics.js
@@ -59,7 +59,7 @@ let cmd = {
   ],
   needsApp: true,
   needsAuth: true,
-  run: cli.command(co.wrap(listTopics))
+  run: cli.command({preauth: true}, co.wrap(listTopics))
 }
 
 module.exports = {

--- a/commands/topics_compaction.js
+++ b/commands/topics_compaction.js
@@ -55,5 +55,5 @@ module.exports = {
     { name: 'VALUE' },
     { name: 'CLUSTER', optional: true }
   ],
-  run: cli.command(co.wrap(compaction))
+  run: cli.command({preauth: true}, co.wrap(compaction))
 }

--- a/commands/topics_create.js
+++ b/commands/topics_create.js
@@ -84,7 +84,7 @@ let cmd = {
       description: 'pass the app name to skip the manual confirmation prompt',
       hasValue: true }
   ],
-  run: cli.command(co.wrap(createTopic))
+  run: cli.command({preauth: true}, co.wrap(createTopic))
 }
 
 module.exports = {

--- a/commands/topics_destroy.js
+++ b/commands/topics_destroy.js
@@ -53,7 +53,7 @@ let cmd = {
       description: 'pass the app name to skip the manual confirmation prompt',
       hasValue: true }
   ],
-  run: cli.command(co.wrap(destroyTopic))
+  run: cli.command({preauth: true}, co.wrap(destroyTopic))
 }
 
 module.exports = {

--- a/commands/topics_info.js
+++ b/commands/topics_info.js
@@ -100,7 +100,7 @@ let cmd = {
 `,
   needsApp: true,
   needsAuth: true,
-  run: cli.command(co.wrap(kafkaTopic))
+  run: cli.command({preauth: true}, co.wrap(kafkaTopic))
 }
 
 module.exports = {

--- a/commands/topics_replication_factor.js
+++ b/commands/topics_replication_factor.js
@@ -49,5 +49,5 @@ module.exports = {
     { name: 'VALUE' },
     { name: 'CLUSTER', optional: true }
   ],
-  run: cli.command(co.wrap(replicationFactor))
+  run: cli.command({preauth: true}, co.wrap(replicationFactor))
 }

--- a/commands/topics_retention_time.js
+++ b/commands/topics_retention_time.js
@@ -56,5 +56,5 @@ module.exports = {
     { name: 'VALUE' },
     { name: 'CLUSTER', optional: true }
   ],
-  run: cli.command(co.wrap(retentionTime))
+  run: cli.command({preauth: true}, co.wrap(retentionTime))
 }

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -57,5 +57,5 @@ module.exports = {
     { name: 'version', description: 'requested kafka version for upgrade', hasValue: true, required: true },
     { name: 'confirm', description: 'pass the app name to skip the manual confirmation prompt', hasValue: true }
   ],
-  run: cli.command(co.wrap(upgradeCluster))
+  run: cli.command({preauth: true}, co.wrap(upgradeCluster))
 }

--- a/commands/zookeeper.js
+++ b/commands/zookeeper.js
@@ -60,5 +60,5 @@ module.exports = {
 `,
   needsApp: true,
   needsAuth: true,
-  run: cli.command(co.wrap(zookeeper))
+  run: cli.command({preauth: true}, co.wrap(zookeeper))
 }


### PR DESCRIPTION
Due to the authentication mechanism we use, we need to be
pre-authenticated anytime we talk to the heroku-kafka API for anything
that requires 2FA. Because the first call we usually make is to the
Heroku API (to get app info about the cluster(s) we are interacting
with), requiring preauth on the commands works around this issue.

The exceptions here are the `topics:tail` and `topics:write` commands,
which talk to the cluster directly and not to the heroku-kafka API.