### PR TITLE
use /data endpoints instead of /client endpoints

### DIFF
--- a/commands/credentials_rotate.js
+++ b/commands/credentials_rotate.js
@@ -11,7 +11,7 @@ function * credentialsRotate (context, heroku) {
   yield withCluster(heroku, context.app, context.args.CLUSTER, function * (addon) {
     let response = yield request(heroku, {
       method: 'POST',
-      path: `/client/kafka/${VERSION}/clusters/${addon.id}/rotate-credentials`
+      path: `/data/kafka/${VERSION}/clusters/${addon.id}/rotate-credentials`
     })
 
     cli.log(response.message)

--- a/commands/fail.js
+++ b/commands/fail.js
@@ -19,7 +19,7 @@ function * fail (context, heroku) {
           catastrophic: context.flags.catastrophic,
           zookeeper: context.flags.zookeeper
         },
-        path: `/client/kafka/${VERSION}/clusters/${addon.id}/induce-failure`
+        path: `/data/kafka/${VERSION}/clusters/${addon.id}/induce-failure`
       })
     }))
 

--- a/commands/jmx.js
+++ b/commands/jmx.js
@@ -26,7 +26,7 @@ function * jmx (context, heroku) {
         body: {
           enabled: enabled
         },
-        path: `/client/kafka/${VERSION}/clusters/${addon.id}/jmx`
+        path: `/data/kafka/${VERSION}/clusters/${addon.id}/jmx`
       })
     }))
   })

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -25,7 +25,7 @@ function * upgradeCluster (context, heroku) {
       body: {
         version: context.flags.version
       },
-      path: `/client/kafka/${VERSION}/clusters/${addon.id}/upgrade`
+      path: `/data/kafka/${VERSION}/clusters/${addon.id}/upgrade`
     })
 
     cli.action.done('started.\n\n')

--- a/commands/zookeeper.js
+++ b/commands/zookeeper.js
@@ -31,7 +31,7 @@ function * zookeeper (context, heroku) {
         body: {
           enabled: enabled
         },
-        path: `/client/kafka/${VERSION}/clusters/${addon.id}/zookeeper`
+        path: `/data/kafka/${VERSION}/clusters/${addon.id}/zookeeper`
       })
     }))
   })

--- a/lib/clusters.js
+++ b/lib/clusters.js
@@ -24,7 +24,7 @@ HerokuKafkaClusters.prototype.waitStatus = function * (addon) {
     return null
   }
   var response = yield this.request({
-    path: `/client/kafka/${VERSION}/clusters/${addon.id}/wait_status`
+    path: `/data/kafka/${VERSION}/clusters/${addon.id}/wait_status`
   }).catch(function (err) {
     if (err.statusCode === 410) {
       return Object.assign({ 'deprovisioned?': true }, errorResponse)

--- a/test/commands/credentials_rotate_test.js
+++ b/test/commands/credentials_rotate_test.js
@@ -26,7 +26,7 @@ describe('kafka:credentials', () => {
   let kafka
 
   let credentialsUrl = (cluster) => {
-    return `/client/kafka/v0/clusters/${cluster}/rotate-credentials`
+    return `/data/kafka/v0/clusters/${cluster}/rotate-credentials`
   }
 
   beforeEach(() => {

--- a/test/commands/fail_test.js
+++ b/test/commands/fail_test.js
@@ -36,7 +36,7 @@ describe('kafka:fail', () => {
   let kafka
 
   let failUrl = (cluster) => {
-    return `/client/kafka/v0/clusters/${cluster}/induce-failure`
+    return `/data/kafka/v0/clusters/${cluster}/induce-failure`
   }
 
   beforeEach(() => {

--- a/test/commands/jmx_test.js
+++ b/test/commands/jmx_test.js
@@ -26,7 +26,7 @@ describe('kafka:jmx', () => {
   let kafka
 
   let configUrl = (cluster) => {
-    return `/client/kafka/v0/clusters/${cluster}/jmx`
+    return `/data/kafka/v0/clusters/${cluster}/jmx`
   }
 
   beforeEach(() => {

--- a/test/commands/upgrade_test.js
+++ b/test/commands/upgrade_test.js
@@ -36,7 +36,7 @@ describe('kafka:upgrade', () => {
   let kafka
 
   let upgradeUrl = (cluster) => {
-    return `/client/kafka/v0/clusters/${cluster}/upgrade`
+    return `/data/kafka/v0/clusters/${cluster}/upgrade`
   }
 
   beforeEach(() => {

--- a/test/commands/wait_test.js
+++ b/test/commands/wait_test.js
@@ -30,7 +30,7 @@ const cmd = proxyquire('../../commands/wait', {
 describe('kafka:wait', () => {
   let kafka
   let waitUrl = (cluster) => {
-    return `/client/kafka/v0/clusters/${cluster}/wait_status`
+    return `/data/kafka/v0/clusters/${cluster}/wait_status`
   }
 
   beforeEach(() => {

--- a/test/commands/zookeeper_test.js
+++ b/test/commands/zookeeper_test.js
@@ -27,7 +27,7 @@ describe('kafka:zookeeper', () => {
   let kafka
 
   let configUrl = (cluster) => {
-    return `/client/kafka/v0/clusters/${cluster}/zookeeper`
+    return `/data/kafka/v0/clusters/${cluster}/zookeeper`
   }
 
   beforeEach(() => {


### PR DESCRIPTION
We're removing the `/client` endpoints entirely, so we need to transfer off them