### PR TITLE
Revert "use addon id instead of name"

### DIFF
--- a/commands/credentials_rotate.js
+++ b/commands/credentials_rotate.js
@@ -11,7 +11,7 @@ function * credentialsRotate (context, heroku) {
   yield withCluster(heroku, context.app, context.args.CLUSTER, function * (addon) {
     let response = yield request(heroku, {
       method: 'POST',
-      path: `/client/kafka/${VERSION}/clusters/${addon.id}/rotate-credentials`
+      path: `/client/kafka/${VERSION}/clusters/${addon.name}/rotate-credentials`
     })
 
     cli.log(response.message)

--- a/commands/fail.js
+++ b/commands/fail.js
@@ -19,7 +19,7 @@ function * fail (context, heroku) {
           catastrophic: context.flags.catastrophic,
           zookeeper: context.flags.zookeeper
         },
-        path: `/client/kafka/${VERSION}/clusters/${addon.id}/induce-failure`
+        path: `/client/kafka/${VERSION}/clusters/${addon.name}/induce-failure`
       })
     }))
 

--- a/commands/info.js
+++ b/commands/info.js
@@ -102,7 +102,7 @@ function * run (context, heroku) {
       cluster: heroku.request({
         host: host(addon),
         method: 'get',
-        path: `/data/kafka/v0/clusters/${addon.id}`
+        path: `/data/kafka/v0/clusters/${addon.name}`
       }).catch(err => {
         if (err.statusCode !== 404) throw err
         cli.warn(`${cli.color.addon(addon.name)} is not yet provisioned.\nRun ${cli.color.cmd('heroku kafka:wait')} to wait until the cluster is provisioned.`)

--- a/commands/jmx.js
+++ b/commands/jmx.js
@@ -26,7 +26,7 @@ function * jmx (context, heroku) {
         body: {
           enabled: enabled
         },
-        path: `/client/kafka/${VERSION}/clusters/${addon.id}/jmx`
+        path: `/client/kafka/${VERSION}/clusters/${addon.name}/jmx`
       })
     }))
   })

--- a/commands/topics.js
+++ b/commands/topics.js
@@ -12,7 +12,7 @@ const VERSION = 'v0'
 function * listTopics (context, heroku) {
   yield withCluster(heroku, context.app, context.args.CLUSTER, function * (addon) {
     let topics = yield request(heroku, {
-      path: `/data/kafka/${VERSION}/clusters/${addon.id}/topics`
+      path: `/data/kafka/${VERSION}/clusters/${addon.name}/topics`
     })
     cli.styledHeader('Kafka Topics on ' + (topics.attachment_name || 'HEROKU_KAFKA'))
     let filtered = topics.topics.filter((t) => t.name !== '__consumer_offsets')

--- a/commands/topics_compaction.js
+++ b/commands/topics_compaction.js
@@ -29,7 +29,7 @@ function * compaction (context, heroku) {
             compaction: enabled
           }
         },
-        path: `/data/kafka/${VERSION}/clusters/${addon.id}/topics/${topicName}`
+        path: `/data/kafka/${VERSION}/clusters/${addon.name}/topics/${topicName}`
       })
     }))
     cli.log(`Use \`heroku kafka:topics:info ${context.args.TOPIC}\` to monitor your topic.`)

--- a/commands/topics_create.js
+++ b/commands/topics_create.js
@@ -48,7 +48,7 @@ function * createTopic (context, heroku) {
             compaction: flags['compaction'] || false
           }
         },
-        path: `/data/kafka/${VERSION}/clusters/${addon.id}/topics`
+        path: `/data/kafka/${VERSION}/clusters/${addon.name}/topics`
       })
     }))
 

--- a/commands/topics_destroy.js
+++ b/commands/topics_destroy.js
@@ -20,7 +20,7 @@ function * destroyTopic (context, heroku) {
         body: {
           topic_name: topicName
         },
-        path: `/data/kafka/${VERSION}/clusters/${addon.id}/topics/${topicName}`
+        path: `/data/kafka/${VERSION}/clusters/${addon.name}/topics/${topicName}`
       })
     }))
 

--- a/commands/topics_info.js
+++ b/commands/topics_info.js
@@ -66,7 +66,7 @@ function * kafkaTopic (context, heroku) {
     const topic = context.args.TOPIC
 
     let info = yield request(heroku, {
-      path: `/data/kafka/${VERSION}/clusters/${addon.id}/topics`
+      path: `/data/kafka/${VERSION}/clusters/${addon.name}/topics`
     })
 
     let forTopic = info.topics.filter((t) => t.name === topic)

--- a/commands/topics_replication_factor.js
+++ b/commands/topics_replication_factor.js
@@ -23,7 +23,7 @@ function * replicationFactor (context, heroku) {
             replication_factor: context.args.VALUE
           }
         },
-        path: `/data/kafka/${VERSION}/clusters/${addon.id}/topics/${topicName}`
+        path: `/data/kafka/${VERSION}/clusters/${addon.name}/topics/${topicName}`
       })
     }))
     cli.log(`Use \`heroku kafka:topics:info ${context.args.TOPIC}\` to monitor your topic.`)

--- a/commands/topics_retention_time.js
+++ b/commands/topics_retention_time.js
@@ -29,7 +29,7 @@ function * retentionTime (context, heroku) {
             retention_time_ms: parsed
           }
         },
-        path: `/data/kafka/${VERSION}/clusters/${addon.id}/topics/${topicName}`
+        path: `/data/kafka/${VERSION}/clusters/${addon.name}/topics/${topicName}`
       })
     }))
 

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -25,7 +25,7 @@ function * upgradeCluster (context, heroku) {
       body: {
         version: context.flags.version
       },
-      path: `/client/kafka/${VERSION}/clusters/${addon.id}/upgrade`
+      path: `/client/kafka/${VERSION}/clusters/${addon.name}/upgrade`
     })
 
     cli.action.done('started.\n\n')

--- a/commands/zookeeper.js
+++ b/commands/zookeeper.js
@@ -31,7 +31,7 @@ function * zookeeper (context, heroku) {
         body: {
           enabled: enabled
         },
-        path: `/client/kafka/${VERSION}/clusters/${addon.id}/zookeeper`
+        path: `/client/kafka/${VERSION}/clusters/${addon.name}/zookeeper`
       })
     }))
   })

--- a/lib/clusters.js
+++ b/lib/clusters.js
@@ -24,7 +24,7 @@ HerokuKafkaClusters.prototype.waitStatus = function * (addon) {
     return null
   }
   var response = yield this.request({
-    path: `/client/kafka/${VERSION}/clusters/${addon.id}/wait_status`
+    path: `/client/kafka/${VERSION}/clusters/${addon.name}/wait_status`
   }).catch(function (err) {
     if (err.statusCode === 410) {
       return Object.assign({ 'deprovisioned?': true }, errorResponse)

--- a/test/commands/credentials_rotate_test.js
+++ b/test/commands/credentials_rotate_test.js
@@ -13,7 +13,7 @@ const nock = require('nock')
 
 let planName
 const withCluster = function * (heroku, app, cluster, callback) {
-  yield callback({ name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000', plan: { name: planName } })
+  yield callback({ name: 'kafka-1', plan: { name: planName } })
 }
 
 const cmd = proxyquire('../../commands/credentials_rotate', {
@@ -42,7 +42,7 @@ describe('kafka:credentials', () => {
   })
 
   it(`rotates credentials`, () => {
-    kafka.post(credentialsUrl('00000000-0000-0000-0000-000000000000')).reply(200, {message: 'Rotated'})
+    kafka.post(credentialsUrl('kafka-1')).reply(200, {message: 'Rotated'})
 
     return cmd.run({app: 'myapp', args: {CLUSTER: undefined}, flags: { reset: true }})
       .then(() => expect(cli.stderr).to.be.empty)

--- a/test/commands/fail_test.js
+++ b/test/commands/fail_test.js
@@ -12,7 +12,7 @@ const nock = require('nock')
 const cli = require('heroku-cli-util')
 
 const withCluster = function * (heroku, app, cluster, callback) {
-  yield callback({ name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000' })
+  yield callback({ name: 'kafka-1' })
 }
 
 let lastApp
@@ -56,7 +56,7 @@ describe('kafka:fail', () => {
     const cluster = 'kafka-1'
     const message = `This command will affect the cluster: ${cluster}, which is on ${app}\n\nThis command will forcibly terminate nodes in your cluster at random.\nYou should only run this command in controlled testing scenarios.`
 
-    kafka.post(failUrl('00000000-0000-0000-0000-000000000000')).reply(200, { message: 'Triggered failure on node 1.2.3.4' })
+    kafka.post(failUrl('kafka-1')).reply(200, { message: 'Triggered failure on node 1.2.3.4' })
 
     return cmd.run({app: 'myapp', args: {}, flags: {confirm: 'myapp'}})
               .then(() => {
@@ -67,7 +67,7 @@ describe('kafka:fail', () => {
   })
 
   it('triggers failure', () => {
-    kafka.post(failUrl('00000000-0000-0000-0000-000000000000', {confirm: 'myapp',
+    kafka.post(failUrl('kafka-1', {confirm: 'myapp',
                                    catastrophic: false,
                                    zookeeper: false}))
          .reply(200, { message: 'Triggered failure on node 1.2.3.4' })
@@ -82,7 +82,7 @@ describe('kafka:fail', () => {
   })
 
   it('passes the --catastrophic flag', () => {
-    kafka.post(failUrl('00000000-0000-0000-0000-000000000000', {confirm: 'myapp',
+    kafka.post(failUrl('kafka-1', {confirm: 'myapp',
                                    catastrophic: true,
                                    zookeeper: false}))
          .reply(200, { message: 'Triggered failure on node 1.2.3.4' })
@@ -97,7 +97,7 @@ describe('kafka:fail', () => {
   })
 
   it('passes the --zookeeper flag', () => {
-    kafka.post(failUrl('00000000-0000-0000-0000-000000000000', {confirm: 'myapp',
+    kafka.post(failUrl('kafka-1', {confirm: 'myapp',
                                    catastrophic: false,
                                    zookeeper: true}))
          .reply(200, { message: 'Triggered failure on node 1.2.3.4' })

--- a/test/commands/info_test.js
+++ b/test/commands/info_test.js
@@ -13,8 +13,8 @@ const nock = require('nock')
 
 let addon
 let all = [
-  {name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000', plan: {name: 'heroku-kafka:beta-3'}},
-  {name: 'kafka-2', id: '00000000-0000-0000-0000-000000000001', plan: {name: 'heroku-kafka:beta-3'}}
+  {name: 'kafka-1', plan: {name: 'heroku-kafka:beta-3'}},
+  {name: 'kafka-2', plan: {name: 'heroku-kafka:beta-3'}}
 ]
 
 const fetcher = () => {
@@ -60,14 +60,14 @@ describe('kafka:info', () => {
   describe('with 2 dbs', () => {
     let plan = {name: 'heroku-kafka:beta-3'}
     let attachments = [
-      { addon: { name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000' }, name: 'KAFKA' },
-      { addon: { name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000' }, name: 'HEROKU_KAFKA_COBALT' },
-      { addon: { name: 'kafka-2', id: '00000000-0000-0000-0000-000000000001' }, name: 'HEROKU_KAFKA_PURPLE' }
+      { addon: { name: 'kafka-1' }, name: 'KAFKA' },
+      { addon: { name: 'kafka-1' }, name: 'HEROKU_KAFKA_COBALT' },
+      { addon: { name: 'kafka-2' }, name: 'HEROKU_KAFKA_PURPLE' }
     ]
     let addonService = {name: 'heroku-kafka'}
     let addons = [
-      {name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000', addon_service: addonService, plan},
-      {name: 'kafka-2', id: '00000000-0000-0000-0000-000000000001', addon_service: addonService, plan}
+      {id: 1, name: 'kafka-1', addon_service: addonService, plan},
+      {id: 2, name: 'kafka-2', addon_service: addonService, plan}
     ]
     let clusterA = {
       addon: { name: 'kafka-1' },
@@ -97,8 +97,8 @@ describe('kafka:info', () => {
 
       api.get('/apps/myapp/addon-attachments').reply(200, attachments)
       kafka
-        .get(infoUrl('00000000-0000-0000-0000-000000000000')).reply(200, clusterA)
-        .get(infoUrl('00000000-0000-0000-0000-000000000001')).reply(200, clusterB)
+        .get(infoUrl('kafka-1')).reply(200, clusterA)
+        .get(infoUrl('kafka-2')).reply(200, clusterB)
 
       return cmd.run({app: 'myapp', args: {}})
         .then(() => expect(cli.stderr).to.be.empty)
@@ -130,7 +130,7 @@ Add-on:   kafka-2
       api.get('/apps/myapp/addon-attachments').reply(200, attachments)
 
       kafka
-        .get(infoUrl('00000000-0000-0000-0000-000000000001'))
+        .get(infoUrl('kafka-2'))
         .reply(200, clusterB)
 
       return cmd.run({app: 'myapp', args: {CLUSTER: 'kafka-2'}})
@@ -153,8 +153,8 @@ Add-on:   kafka-2
 
       api.get('/apps/myapp/addon-attachments').reply(200, attachments)
       kafka
-        .get(infoUrl('00000000-0000-0000-0000-000000000000')).reply(404)
-        .get(infoUrl('00000000-0000-0000-0000-000000000001')).reply(200, clusterB)
+        .get(infoUrl('kafka-1')).reply(404)
+        .get(infoUrl('kafka-2')).reply(200, clusterB)
 
       return cmd.run({app: 'myapp', args: {}})
         .then(() => expect(cli.stdout).to.equal(`=== HEROKU_KAFKA_PURPLE_URL

--- a/test/commands/jmx_test.js
+++ b/test/commands/jmx_test.js
@@ -13,7 +13,7 @@ const cli = require('heroku-cli-util')
 const nock = require('nock')
 
 const withCluster = function * (heroku, app, cluster, callback) {
-  yield callback({ name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000' })
+  yield callback({ name: 'kafka-1' })
 }
 
 const cmd = proxyquire('../../commands/jmx', {
@@ -53,7 +53,7 @@ describe('kafka:jmx', () => {
   const validEnable = [ 'enable', 'on' ]
   validEnable.forEach((value) => {
     it(`turns JMX on with argument ${value}`, () => {
-      kafka.post(configUrl('00000000-0000-0000-0000-000000000000'), { enabled: true }).reply(200)
+      kafka.post(configUrl('kafka-1'), { enabled: true }).reply(200)
 
       return cmd.run({app: 'myapp', args: { VALUE: value }})
                 .then(() => expect(cli.stderr).to.equal('Enabling JMX access... done\n'))
@@ -64,7 +64,7 @@ describe('kafka:jmx', () => {
   const validDisable = [ 'disable', 'off' ]
   validDisable.forEach((value) => {
     it(`turns JMX off with argument ${value}`, () => {
-      kafka.post(configUrl('00000000-0000-0000-0000-000000000000'), { enabled: false }).reply(200)
+      kafka.post(configUrl('kafka-1'), { enabled: false }).reply(200)
 
       return cmd.run({app: 'myapp', args: { VALUE: value }})
                 .then(() => expect(cli.stderr).to.equal('Disabling JMX access... done\n'))

--- a/test/commands/topics_compaction_test.js
+++ b/test/commands/topics_compaction_test.js
@@ -13,7 +13,7 @@ const cli = require('heroku-cli-util')
 const nock = require('nock')
 
 const withCluster = function * (heroku, app, cluster, callback) {
-  yield callback({ name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000' })
+  yield callback({ name: 'kafka-1' })
 }
 
 const cmd = proxyquire('../../commands/topics_compaction', {
@@ -54,7 +54,7 @@ describe('kafka:topics:compaction', () => {
   const validEnable = [ 'enable', 'on' ]
   validEnable.forEach((value) => {
     it(`turns compaction on with argument ${value}`, () => {
-      kafka.put(topicConfigUrl('00000000-0000-0000-0000-000000000000', 'topic-1'),
+      kafka.put(topicConfigUrl('kafka-1', 'topic-1'),
                 { topic: { name: 'topic-1', compaction: true } }).reply(200)
 
       return cmd.run({app: 'myapp', args: { TOPIC: 'topic-1', VALUE: value }})
@@ -66,7 +66,7 @@ describe('kafka:topics:compaction', () => {
   const validDisable = [ 'disable', 'off' ]
   validDisable.forEach((value) => {
     it(`turns compaction off with argument ${value}`, () => {
-      kafka.put(topicConfigUrl('00000000-0000-0000-0000-000000000000', 'topic-1'),
+      kafka.put(topicConfigUrl('kafka-1', 'topic-1'),
                 { topic: { name: 'topic-1', compaction: false } }).reply(200)
 
       return cmd.run({app: 'myapp', args: { TOPIC: 'topic-1', VALUE: value }})

--- a/test/commands/topics_create_test.js
+++ b/test/commands/topics_create_test.js
@@ -13,7 +13,7 @@ const cli = require('heroku-cli-util')
 const nock = require('nock')
 
 const withCluster = function * (heroku, app, cluster, callback) {
-  yield callback({ name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000' })
+  yield callback({ name: 'kafka-1' })
 }
 
 let lastApp
@@ -66,7 +66,7 @@ describe('kafka:topics:create', () => {
   it('requires app confirmation and warns if replication factor of 1 specified', () => {
     const message = `This command will create a topic with no replication on the cluster: kafka-1, which is on myapp.\nData written to this topic will be lost if any single broker suffers catastrophic failure.`
 
-    kafka.post(createUrl('00000000-0000-0000-0000-000000000000')).reply(200, { message: 'success' })
+    kafka.post(createUrl('kafka-1')).reply(200, { message: 'success' })
 
     lastApp = null
     lastConfirm = null
@@ -86,7 +86,7 @@ describe('kafka:topics:create', () => {
   })
 
   it('does not require app confirmation with higher replication factor', () => {
-    kafka.post(createUrl('00000000-0000-0000-0000-000000000000')).reply(200)
+    kafka.post(createUrl('kafka-1')).reply(200)
 
     lastApp = null
     lastConfirm = null
@@ -103,7 +103,7 @@ describe('kafka:topics:create', () => {
   })
 
   it('passes the topic name and specified flags', () => {
-    kafka.post(createUrl('00000000-0000-0000-0000-000000000000'),
+    kafka.post(createUrl('kafka-1'),
       {
         topic: {
           name: 'topic-1',
@@ -126,7 +126,7 @@ describe('kafka:topics:create', () => {
   })
 
   it('defaults to 32 partitions', () => {
-    kafka.post(createUrl('00000000-0000-0000-0000-000000000000'),
+    kafka.post(createUrl('kafka-1'),
       {
         topic: {
           name: 'topic-1',

--- a/test/commands/topics_destroy_test.js
+++ b/test/commands/topics_destroy_test.js
@@ -12,7 +12,7 @@ const cli = require('heroku-cli-util')
 const nock = require('nock')
 
 const withCluster = function * (heroku, app, cluster, callback) {
-  yield callback({ name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000' })
+  yield callback({ name: 'kafka-1' })
 }
 
 let lastApp
@@ -57,7 +57,7 @@ describe('kafka:topics:destroy', () => {
   it('requires app confirmation', () => {
     const message = 'This command will affect the cluster: kafka-1, which is on myapp'
 
-    kafka.delete(deleteUrl('00000000-0000-0000-0000-000000000000', 'topic-1')).reply(200)
+    kafka.delete(deleteUrl('kafka-1', 'topic-1')).reply(200)
 
     lastApp = null
     lastConfirm = null
@@ -74,7 +74,7 @@ describe('kafka:topics:destroy', () => {
   })
 
   it('deletes the topic', () => {
-    kafka.delete(deleteUrl('00000000-0000-0000-0000-000000000000', 'topic-1'), { topic_name: 'topic-1' })
+    kafka.delete(deleteUrl('kafka-1', 'topic-1'), { topic_name: 'topic-1' })
          .reply(200)
 
     return cmd.run({app: 'myapp',

--- a/test/commands/topics_info_test.js
+++ b/test/commands/topics_info_test.js
@@ -12,7 +12,7 @@ const cli = require('heroku-cli-util')
 const nock = require('nock')
 
 const withCluster = function * (heroku, app, cluster, callback) {
-  yield callback({ name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000' })
+  yield callback({ name: 'kafka-1' })
 }
 
 const cmd = proxyquire('../../commands/topics_info', {
@@ -40,7 +40,7 @@ describe('kafka:topics:info', () => {
   })
 
   it('displays the topic info', () => {
-    kafka.get(topicsUrl('00000000-0000-0000-0000-000000000000')).reply(200, {
+    kafka.get(topicsUrl('kafka-1')).reply(200, {
       attachment_name: 'HEROKU_KAFKA_BLUE_URL',
       topics: [
         {

--- a/test/commands/topics_replication_factor_test.js
+++ b/test/commands/topics_replication_factor_test.js
@@ -12,7 +12,7 @@ const cli = require('heroku-cli-util')
 const nock = require('nock')
 
 const withCluster = function * (heroku, app, cluster, callback) {
-  yield callback({ name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000' })
+  yield callback({ name: 'kafka-1' })
 }
 
 const cmd = proxyquire('../../commands/topics_replication_factor', {
@@ -40,7 +40,7 @@ describe('kafka:topics:replication-factor', () => {
   })
 
   it('sets replication factor to the specified value', () => {
-    kafka.put(topicConfigUrl('00000000-0000-0000-0000-000000000000', 'topic-1'),
+    kafka.put(topicConfigUrl('kafka-1', 'topic-1'),
               { topic: { name: 'topic-1', replication_factor: '5' } }).reply(200)
 
     return cmd.run({app: 'myapp', args: { TOPIC: 'topic-1', VALUE: '5' }})

--- a/test/commands/topics_retention_time_test.js
+++ b/test/commands/topics_retention_time_test.js
@@ -13,7 +13,7 @@ const cli = require('heroku-cli-util')
 const nock = require('nock')
 
 const withCluster = function * (heroku, app, cluster, callback) {
-  yield callback({ name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000' })
+  yield callback({ name: 'kafka-1' })
 }
 
 const cmd = proxyquire('../../commands/topics_retention_time', {
@@ -51,7 +51,7 @@ describe('kafka:topics:retention-time', () => {
   })
 
   it('sets retention time to the specified value', () => {
-    kafka.put(topicConfigUrl('00000000-0000-0000-0000-000000000000', 'topic-1'),
+    kafka.put(topicConfigUrl('kafka-1', 'topic-1'),
               { topic: { name: 'topic-1', retention_time_ms: 60000 } }).reply(200)
 
     return cmd.run({app: 'myapp',

--- a/test/commands/topics_tail_test.js
+++ b/test/commands/topics_tail_test.js
@@ -14,7 +14,7 @@ const nock = require('nock')
 
 let planName
 const withCluster = function * (heroku, app, cluster, callback) {
-  yield callback({ name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000', plan: { name: planName } })
+  yield callback({ name: 'kafka-1', plan: { name: planName } })
 }
 
 let consumer

--- a/test/commands/topics_test.js
+++ b/test/commands/topics_test.js
@@ -12,7 +12,7 @@ const cli = require('heroku-cli-util')
 const nock = require('nock')
 
 const withCluster = function * (heroku, app, cluster, callback) {
-  yield callback({ name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000' })
+  yield callback({ name: 'kafka-1' })
 }
 
 const cmd = proxyquire('../../commands/topics', {
@@ -41,7 +41,7 @@ describe('kafka:topics', () => {
 
   describe('with no topics in the cluster', () => {
     it('indicates there are no topics', () => {
-      kafka.get(topicsUrl('00000000-0000-0000-0000-000000000000')).reply(200, {
+      kafka.get(topicsUrl('kafka-1')).reply(200, {
         attachment_name: 'HEROKU_KAFKA_BLUE_URL',
         topics: []
       })
@@ -56,7 +56,7 @@ Use heroku kafka:topics:create to create a topic.
     })
 
     it('ignores the __consumer_offsets topic', () => {
-      kafka.get(topicsUrl('00000000-0000-0000-0000-000000000000')).reply(200, {
+      kafka.get(topicsUrl('kafka-1')).reply(200, {
         attachment_name: 'HEROKU_KAFKA_BLUE_URL',
         topics: [
           { name: '__consumer_offsets', messages_in_per_second: 9.0, bytes_in_per_second: 2 }
@@ -75,7 +75,7 @@ Use heroku kafka:topics:create to create a topic.
 
   describe('with some topics in the cluster', () => {
     it('displays information about these topics', () => {
-      kafka.get(topicsUrl('00000000-0000-0000-0000-000000000000')).reply(200, {
+      kafka.get(topicsUrl('kafka-1')).reply(200, {
         attachment_name: 'HEROKU_KAFKA_BLUE_URL',
         topics: [
           { name: 'topic-1', messages_in_per_second: 10.0, bytes_in_per_second: 0 },
@@ -95,7 +95,7 @@ topic-2  12/sec    3 bytes/sec
     })
 
     it('omits information about the special __consumer_offsets topic', () => {
-      kafka.get(topicsUrl('00000000-0000-0000-0000-000000000000')).reply(200, {
+      kafka.get(topicsUrl('kafka-1')).reply(200, {
         attachment_name: 'HEROKU_KAFKA_BLUE_URL',
         topics: [
           { name: '__consumer_offsets', messages_in_per_second: '9.0', bytes: '2' },

--- a/test/commands/topics_write_test.js
+++ b/test/commands/topics_write_test.js
@@ -14,7 +14,7 @@ const nock = require('nock')
 
 let planName
 const withCluster = function * (heroku, app, cluster, callback) {
-  yield callback({ name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000', plan: { name: planName } })
+  yield callback({ name: 'kafka-1', plan: { name: planName } })
 }
 
 let producer

--- a/test/commands/upgrade_test.js
+++ b/test/commands/upgrade_test.js
@@ -12,7 +12,7 @@ const nock = require('nock')
 const cli = require('heroku-cli-util')
 
 const withCluster = function * (heroku, app, cluster, callback) {
-  yield callback({ name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000' })
+  yield callback({ name: 'kafka-1' })
 }
 
 let lastApp
@@ -54,7 +54,7 @@ describe('kafka:upgrade', () => {
   it('requires app confirmation', () => {
     const message = 'This command will upgrade the brokers of the cluster to version 0.10.'
 
-    kafka.put(upgradeUrl('00000000-0000-0000-0000-000000000000')).reply(200)
+    kafka.put(upgradeUrl('kafka-1')).reply(200)
 
     return cmd.run({app: 'myapp',
                     args: {},
@@ -67,7 +67,7 @@ describe('kafka:upgrade', () => {
   })
 
   it('triggers an upgrade to the desired version', () => {
-    kafka.put(upgradeUrl('00000000-0000-0000-0000-000000000000', {confirm: 'myapp',
+    kafka.put(upgradeUrl('kafka-1', {confirm: 'myapp',
                                      version: '0.10'}))
          .reply(200, { message: 'Triggered failure on node 1.2.3.4' })
 

--- a/test/commands/wait_test.js
+++ b/test/commands/wait_test.js
@@ -12,8 +12,8 @@ const cli = require('heroku-cli-util')
 const nock = require('nock')
 
 const all = [
-  {name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000', plan: {name: 'heroku-kafka:beta-3'}},
-  {name: 'kafka-2', id: '00000000-0000-0000-0000-000000000001', plan: {name: 'heroku-kafka:beta-3'}}
+  {name: 'kafka-1', plan: {name: 'heroku-kafka:beta-3'}},
+  {name: 'kafka-2', plan: {name: 'heroku-kafka:beta-3'}}
 ]
 
 const fetcher = () => {
@@ -46,8 +46,8 @@ describe('kafka:wait', () => {
 
   it('waits for a cluster to be available', () => {
     kafka
-      .get(waitUrl('00000000-0000-0000-0000-000000000000')).reply(200, {'waiting?': true, message: 'pending'})
-      .get(waitUrl('00000000-0000-0000-0000-000000000000')).reply(200, {'waiting?': false, message: 'available'})
+      .get(waitUrl('kafka-1')).reply(200, {'waiting?': true, message: 'pending'})
+      .get(waitUrl('kafka-1')).reply(200, {'waiting?': false, message: 'available'})
 
     return cmd.run({app: 'myapp', args: {cluster: 'KAFKA_URL'}, flags: {'wait-interval': '1'}})
       .then(() => expect(cli.stdout).to.be.empty)
@@ -58,8 +58,8 @@ Waiting for cluster kafka-1... available
 
   it('waits for all clusters to be available', () => {
     kafka
-      .get(waitUrl('00000000-0000-0000-0000-000000000000')).reply(200, {'waiting?': false})
-      .get(waitUrl('00000000-0000-0000-0000-000000000001')).reply(200, {'waiting?': false})
+      .get(waitUrl('kafka-1')).reply(200, {'waiting?': false})
+      .get(waitUrl('kafka-2')).reply(200, {'waiting?': false})
 
     return cmd.run({app: 'myapp', args: {}, flags: {}})
       .then(() => expect(cli.stdout, 'to equal', ''))
@@ -68,7 +68,7 @@ Waiting for cluster kafka-1... available
 
   it('displays errors', () => {
     kafka
-      .get(waitUrl('00000000-0000-0000-0000-000000000000')).reply(200, {'error?': true, message: 'this is an error message'})
+      .get(waitUrl('kafka-1')).reply(200, {'error?': true, message: 'this is an error message'})
 
     return cmd.run({app: 'myapp', args: {}, flags: {}})
       .catch(err => {

--- a/test/commands/zookeeper_test.js
+++ b/test/commands/zookeeper_test.js
@@ -14,7 +14,7 @@ const nock = require('nock')
 
 let planName
 const withCluster = function * (heroku, app, cluster, callback) {
-  yield callback({ name: 'kafka-1', id: '00000000-0000-0000-0000-000000000000', plan: { name: planName } })
+  yield callback({ name: 'kafka-1', plan: { name: planName } })
 }
 
 const cmd = proxyquire('../../commands/zookeeper', {
@@ -62,7 +62,7 @@ describe('kafka:zookeeper', () => {
   const validEnable = [ 'enable', 'on' ]
   validEnable.forEach((value) => {
     it(`turns zookeeper on with argument ${value}`, () => {
-      kafka.post(configUrl('00000000-0000-0000-0000-000000000000'), { enabled: true }).reply(200)
+      kafka.post(configUrl('kafka-1'), { enabled: true }).reply(200)
 
       return cmd.run({app: 'myapp', args: { VALUE: value }})
                 .then(() => expect(cli.stderr).to.equal('Enabling Zookeeper access... done\n'))
@@ -73,7 +73,7 @@ describe('kafka:zookeeper', () => {
   const validDisable = [ 'disable', 'off' ]
   validDisable.forEach((value) => {
     it(`turns zookeeper off with argument ${value}`, () => {
-      kafka.post(configUrl('00000000-0000-0000-0000-000000000000'), { enabled: false }).reply(200)
+      kafka.post(configUrl('kafka-1'), { enabled: false }).reply(200)
 
       return cmd.run({app: 'myapp', args: { VALUE: value }})
                 .then(() => expect(cli.stderr).to.equal('Disabling Zookeeper access... done\n'))


### PR DESCRIPTION
Reverts heroku/heroku-kafka-jsplugin#122

I just tested this manually *after* merging it and things broke. Will investigate but let's revert for now.