### PR TITLE
warn users about upgrades in the confirm text

### DIFF
--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -10,7 +10,9 @@ const VERSION = 'v0'
 function * upgradeCluster (context, heroku) {
   yield withCluster(heroku, context.app, context.args.CLUSTER, function * (addon) {
     yield cli.confirmApp(context.app, context.flags.confirm,
-                         `This command will upgrade the brokers of the cluster to version ${context.flags.version}.`)
+                         `This command will upgrade the brokers of the cluster to version ${context.flags.version}.
+                          Upgrading the cluster involves rolling restarts of brokers, and takes some time, depending on the
+                          size of the cluster.`)
 
     let msg = 'Upgrading '
     if (context.args.CLUSTER) {
@@ -30,9 +32,6 @@ function * upgradeCluster (context, heroku) {
 
     cli.action.done('started.\n\n')
 
-    cli.log('Upgrading versions on a cluster involves rolling restarts')
-    cli.log('and takes some time, depending on the size of the cluster')
-    cli.log()
     cli.log('Use `heroku kafka:wait` to monitor the upgrade.')
   })
 }

--- a/test/commands/upgrade_test.js
+++ b/test/commands/upgrade_test.js
@@ -52,7 +52,9 @@ describe('kafka:upgrade', () => {
   })
 
   it('requires app confirmation', () => {
-    const message = 'This command will upgrade the brokers of the cluster to version 0.10.'
+    const message = `This command will upgrade the brokers of the cluster to version 0.10.
+                          Upgrading the cluster involves rolling restarts of brokers, and takes some time, depending on the
+                          size of the cluster.`
 
     kafka.put(upgradeUrl('00000000-0000-0000-0000-000000000000')).reply(200)
 
@@ -75,6 +77,6 @@ describe('kafka:upgrade', () => {
                     args: {},
                     flags: {confirm: 'myapp', version: '0.10'}})
               .then(() => expect(cli.stderr).to.equal('Upgrading to version 0.10... started.\n\n\n'))
-              .then(() => expect(cli.stdout).to.equal('Upgrading versions on a cluster involves rolling restarts\nand takes some time, depending on the size of the cluster\n\nUse `heroku kafka:wait` to monitor the upgrade.\n'))
+              .then(() => expect(cli.stdout).to.equal('Use `heroku kafka:wait` to monitor the upgrade.\n'))
   })
 })


### PR DESCRIPTION
tell them "we're going to restart nodes" before they actually start that