### PR TITLE
do not set default_partitions for topic creation

### DIFF
--- a/commands/topics_create.js
+++ b/commands/topics_create.js
@@ -8,7 +8,6 @@ let withCluster = require('../lib/clusters').withCluster
 let request = require('../lib/clusters').request
 
 const VERSION = 'v0'
-const DEFAULT_PARTITIONS = '32'
 
 function * createTopic (context, heroku) {
   var flags = Object.assign({}, context.flags)
@@ -19,9 +18,6 @@ function * createTopic (context, heroku) {
       cli.exit(1, `Could not parse retention time '${value}'; expected value like '10d' or '36h'`)
     }
     flags['retention-time'] = parsed
-  }
-  if (!('partitions' in flags)) {
-    flags['partitions'] = DEFAULT_PARTITIONS
   }
 
   yield withCluster(heroku, context.app, context.args.CLUSTER, function * (addon) {

--- a/test/commands/topics_create_test.js
+++ b/test/commands/topics_create_test.js
@@ -124,26 +124,4 @@ describe('kafka:topics:create', () => {
                 expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n')
               })
   })
-
-  it('defaults to 32 partitions', () => {
-    kafka.post(createUrl('00000000-0000-0000-0000-000000000000'),
-      {
-        topic: {
-          name: 'topic-1',
-          retention_time_ms: 10,
-          replication_factor: '3',
-          partition_count: '32',
-          compaction: false
-        }
-      }).reply(200)
-
-    return cmd.run({app: 'myapp',
-                    args: { TOPIC: 'topic-1' },
-                    flags: { 'replication-factor': '3',
-                             'retention-time': '10ms' }})
-              .then(() => {
-                expect(cli.stderr).to.equal('Creating topic topic-1... done\n')
-                expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n')
-              })
-  })
 })


### PR DESCRIPTION
We should not set the `default_partitions` for topic creation. We will let the addon plan determine the default_partitions if the user does not explicitly set them on the command line.