### PR TITLE
add topic prefix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ $ heroku plugins:install heroku-kafka
 
 For normal development, the initial setup is:
 ``` sh-session
+# ensure node 6.x is installed
 $ npm install
 $ heroku plugins:link .
 ```

--- a/commands/topics_tail.js
+++ b/commands/topics_tail.js
@@ -28,8 +28,8 @@ function * tail (context, heroku) {
       clientId: CLIENT_ID,
       connectionString: config.url,
       ssl: {
-        cert: config.clientCert,
-        key: config.clientCertKey
+        clientCert: config.clientCert,
+        clientCertKey: config.clientCertKey
       },
       logger: {
         logLevel: 0

--- a/commands/topics_tail.js
+++ b/commands/topics_tail.js
@@ -28,8 +28,8 @@ function * tail (context, heroku) {
       clientId: CLIENT_ID,
       connectionString: config.url,
       ssl: {
-        clientCert: config.clientCert,
-        clientCertKey: config.clientCertKey
+        cert: config.clientCert,
+        key: config.clientCertKey
       },
       logger: {
         logLevel: 0
@@ -42,12 +42,17 @@ function * tail (context, heroku) {
       cli.exit(1, 'Could not connect to kafka')
     }
 
+    var topicName = context.args.TOPIC
+    if (config.prefix) {
+      topicName = `${config.prefix}${context.args.TOPIC}`
+    }
+
     try {
-      consumer.subscribe(context.args.TOPIC, (messageSet, topic, partition) => {
+      consumer.subscribe(topicName, (messageSet, topic, partition) => {
         messageSet.forEach((m) => {
           let buffer = m.message.value
           if (buffer == null) {
-            cli.log(context.args.TOPIC, partition, m.offset, 0, 'NULL')
+            cli.log(topicName, partition, m.offset, 0, 'NULL')
             return
           }
           let length = Math.min(buffer.length, MAX_LENGTH)

--- a/commands/topics_write.js
+++ b/commands/topics_write.js
@@ -28,8 +28,8 @@ function * write (context, heroku) {
       clientId: CLIENT_ID,
       connectionString: config.url,
       ssl: {
-        cert: config.clientCert,
-        key: config.clientCertKey
+        clientCert: config.clientCert,
+        clientCertKey: config.clientCertKey
       },
       logger: {
         logLevel: 0

--- a/commands/topics_write.js
+++ b/commands/topics_write.js
@@ -28,13 +28,14 @@ function * write (context, heroku) {
       clientId: CLIENT_ID,
       connectionString: config.url,
       ssl: {
-        clientCert: config.clientCert,
-        clientCertKey: config.clientCertKey
+        cert: config.clientCert,
+        key: config.clientCertKey
       },
       logger: {
         logLevel: 0
       }
     })
+
     try {
       yield producer.init()
     } catch (e) {
@@ -42,7 +43,10 @@ function * write (context, heroku) {
       cli.exit(1, 'Could not connect to kafka')
     }
 
-    const topicName = context.args.TOPIC
+    var topicName = context.args.TOPIC
+    if (config.prefix) {
+      topicName = `${config.prefix}${context.args.TOPIC}`
+    }
     const partition = parseInt(context.flags.partition) || 0
     const key = context.flags.key
 

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -19,7 +19,8 @@ function clusterConfig (attachment, config) {
     url: config[attachment.name + '_URL'],
     trustedCert: config[attachment.name + 'TRUSTED_CERT'],
     clientCert: config[attachment.name + '_CLIENT_CERT'],
-    clientCertKey: config[attachment.name + '_CLIENT_CERT_KEY']
+    clientCertKey: config[attachment.name + '_CLIENT_CERT_KEY'],
+    prefix: config[attachment.name + '_PREFIX']
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "heroku-cli-util": "6.0.15",
     "humanize-plus": "^1.8.2",
     "lodash.uniqby": "4.6.1",
-    "no-kafka": "github:hunterloftis/kafka",
+    "no-kafka": "3.1.0",
     "node-spinner": "0.0.4"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "heroku-cli-util": "6.0.15",
     "humanize-plus": "^1.8.2",
     "lodash.uniqby": "4.6.1",
-    "no-kafka": "3.1.0",
+    "no-kafka": "github:hunterloftis/kafka",
     "node-spinner": "0.0.4"
   },
   "scripts": {


### PR DESCRIPTION
Some users may have prefixed topic names. This commit adds support for prepending the prefix to the topic name when producing and consuming.

Additionally, the `no-kafka` dependency is updated and locked to 3.1.0.