### PR TITLE
prefix all arguments if prefix exists

### DIFF
--- a/commands/consumer_groups_create.js
+++ b/commands/consumer_groups_create.js
@@ -4,12 +4,24 @@ let cli = require('heroku-cli-util')
 let co = require('co')
 let withCluster = require('../lib/clusters').withCluster
 let request = require('../lib/clusters').request
+let clusterConfig = require('../lib/shared').clusterConfig
 
 const VERSION = 'v0'
 
 function * createConsumerGroup (context, heroku) {
   yield withCluster(heroku, context.app, context.args.CLUSTER, function * (addon) {
-    let msg = `Creating consumer group ${context.args.CONSUMER_GROUP}`
+    let appConfig = yield heroku.get(`/apps/${context.app}/config-vars`)
+    let attachment = yield heroku.get(`/apps/${context.app}/addon-attachments/${addon.name}`)
+    let config = clusterConfig(attachment, appConfig)
+
+    var consumerGroupName = context.args.CONSUMER_GROUP
+    var consumerGroupNameArray = consumerGroupName.split(/(\.)/g)
+    var consumerGroupPrefix = consumerGroupNameArray[0] + consumerGroupNameArray[1]
+    if (config.prefix && (config.prefix !== consumerGroupPrefix)) {
+      consumerGroupName = `${config.prefix}${context.args.CONSUMER_GROUP}`
+    }
+
+    let msg = `Creating consumer group ${consumerGroupName}`
     if (context.args.CLUSTER) {
       msg += ` on ${context.args.CLUSTER}`
     }
@@ -19,14 +31,14 @@ function * createConsumerGroup (context, heroku) {
         method: 'POST',
         body: {
           consumer_group: {
-            name: context.args.CONSUMER_GROUP
+            name: consumerGroupName
           }
         },
         path: `/data/kafka/${VERSION}/clusters/${addon.id}/consumer_groups`
       })
     }))
 
-    cli.log(`Use \`heroku kafka:consumer-groups:info ${context.args.CONSUMER_GROUP}\` to monitor your consumer group.`)
+    cli.log(`Use \`heroku kafka:consumer-groups:info ${consumerGroupName}\` to monitor your consumer group.`)
   })
 }
 

--- a/commands/topics_replication_factor.js
+++ b/commands/topics_replication_factor.js
@@ -4,17 +4,29 @@ let cli = require('heroku-cli-util')
 let co = require('co')
 let withCluster = require('../lib/clusters').withCluster
 let request = require('../lib/clusters').request
+let clusterConfig = require('../lib/shared').clusterConfig
 
 const VERSION = 'v0'
 
 function * replicationFactor (context, heroku) {
-  let msg = `Setting replication factor for topic ${context.args.TOPIC} to ${context.args.VALUE}`
-  if (context.args.CLUSTER) {
-    msg += ` on ${context.args.CLUSTER}`
-  }
   yield withCluster(heroku, context.app, context.args.CLUSTER, function * (addon) {
+    let appConfig = yield heroku.get(`/apps/${context.app}/config-vars`)
+    let attachment = yield heroku.get(`/apps/${context.app}/addon-attachments/${addon.name}`)
+    let config = clusterConfig(attachment, appConfig)
+
+    var topicName = context.args.TOPIC
+    var topicNameArray = topicName.split(/(\.)/g)
+    var topicPrefix = topicNameArray[0] + topicNameArray[1]
+    if (config.prefix && (config.prefix !== topicPrefix)) {
+      topicName = `${config.prefix}${context.args.TOPIC}`
+    }
+
+    let msg = `Setting replication factor for topic ${topicName} to ${context.args.VALUE}`
+    if (context.args.CLUSTER) {
+      msg += ` on ${context.args.CLUSTER}`
+    }
+
     yield cli.action(msg, co(function * () {
-      const topicName = context.args.TOPIC
       return yield request(heroku, {
         method: 'PUT',
         body: {
@@ -26,7 +38,7 @@ function * replicationFactor (context, heroku) {
         path: `/data/kafka/${VERSION}/clusters/${addon.id}/topics/${topicName}`
       })
     }))
-    cli.log(`Use \`heroku kafka:topics:info ${context.args.TOPIC}\` to monitor your topic.`)
+    cli.log(`Use \`heroku kafka:topics:info ${topicName}\` to monitor your topic.`)
   })
 }
 

--- a/commands/topics_retention_time.js
+++ b/commands/topics_retention_time.js
@@ -5,6 +5,7 @@ let co = require('co')
 let parseDuration = require('../lib/shared').parseDuration
 let withCluster = require('../lib/clusters').withCluster
 let request = require('../lib/clusters').request
+let clusterConfig = require('../lib/shared').clusterConfig
 
 const VERSION = 'v0'
 
@@ -14,13 +15,24 @@ function * retentionTime (context, heroku) {
     cli.exit(1, `Unknown retention time '${context.args.VALUE}'; expected value like '36h' or '10d'`)
   }
 
-  let msg = `Setting retention time for topic ${context.args.TOPIC} to ${context.args.VALUE}`
-  if (context.args.CLUSTER) {
-    msg += ` on ${context.args.CLUSTER}`
-  }
   yield withCluster(heroku, context.app, context.args.CLUSTER, function * (addon) {
+    let appConfig = yield heroku.get(`/apps/${context.app}/config-vars`)
+    let attachment = yield heroku.get(`/apps/${context.app}/addon-attachments/${addon.name}`)
+    let config = clusterConfig(attachment, appConfig)
+
+    var topicName = context.args.TOPIC
+    var topicNameArray = topicName.split(/(\.)/g)
+    var topicPrefix = topicNameArray[0] + topicNameArray[1]
+    if (config.prefix && (config.prefix !== topicPrefix)) {
+      topicName = `${config.prefix}${context.args.TOPIC}`
+    }
+
+    let msg = `Setting retention time for topic ${topicName} to ${context.args.VALUE}`
+    if (context.args.CLUSTER) {
+      msg += ` on ${context.args.CLUSTER}`
+    }
+
     yield cli.action(msg, co(function * () {
-      const topicName = context.args.TOPIC
       return yield request(heroku, {
         method: 'PUT',
         body: {
@@ -33,7 +45,7 @@ function * retentionTime (context, heroku) {
       })
     }))
 
-    cli.log(`Use \`heroku kafka:topics:info ${context.args.TOPIC}\` to monitor your topic.`)
+    cli.log(`Use \`heroku kafka:topics:info ${topicName}\` to monitor your topic.`)
   })
 }
 

--- a/commands/topics_tail.js
+++ b/commands/topics_tail.js
@@ -43,7 +43,10 @@ function * tail (context, heroku) {
     }
 
     var topicName = context.args.TOPIC
-    if (config.prefix) {
+    var topicNameArray = topicName.split(/(\.)/g)
+    var topicPrefix = topicNameArray[0] + topicNameArray[1]
+
+    if (config.prefix && (config.prefix !== topicPrefix)) {
       topicName = `${config.prefix}${context.args.TOPIC}`
     }
 

--- a/commands/topics_write.js
+++ b/commands/topics_write.js
@@ -46,7 +46,6 @@ function * write (context, heroku) {
     var topicName = context.args.TOPIC
     var topicNameArray = topicName.split(/(\.)/g)
     var topicPrefix = topicNameArray[0] + topicNameArray[1]
-
     if (config.prefix && (config.prefix !== topicPrefix)) {
       topicName = `${config.prefix}${context.args.TOPIC}`
     }

--- a/commands/topics_write.js
+++ b/commands/topics_write.js
@@ -44,7 +44,10 @@ function * write (context, heroku) {
     }
 
     var topicName = context.args.TOPIC
-    if (config.prefix) {
+    var topicNameArray = topicName.split(/(\.)/g)
+    var topicPrefix = topicNameArray[0] + topicNameArray[1]
+
+    if (config.prefix && (config.prefix !== topicPrefix)) {
       topicName = `${config.prefix}${context.args.TOPIC}`
     }
     const partition = parseInt(context.flags.partition) || 0

--- a/test/commands/topics_tail_test.js
+++ b/test/commands/topics_tail_test.js
@@ -139,4 +139,27 @@ describe('kafka:topics:tail', () => {
                 expect(cli.stderr).to.be.empty
               })
   })
+
+  it('tails a topic with a prefixed name and prints the results', () => {
+    var withPrefixConfig = {}
+    Object.assign(withPrefixConfig, config)
+    withPrefixConfig.KAFKA_PREFIX = 'nile-1234.'
+    api.get('/apps/myapp/config-vars').reply(200, withPrefixConfig)
+    api.get('/apps/myapp/addon-attachments/kafka-1')
+      .reply(200, { name: 'KAFKA' })
+
+    consumer.subscribe = (topic, callback) => {
+      expect(topic).to.equal('nile-1234.topic-1')
+      callback([
+        { offset: 1, message: { value: Buffer.from('hello') } },
+        { offset: 2, message: { value: Buffer.from('world') } }
+      ], undefined, 42)
+    }
+
+    return cmd.run({app: 'myapp', args: { TOPIC: 'nile-1234.topic-1' }})
+              .then(() => {
+                expect(cli.stdout).to.equal('nile-1234.topic-1 42 1 5 hello\nnile-1234.topic-1 42 2 5 world\n')
+                expect(cli.stderr).to.be.empty
+              })
+  })
 })

--- a/test/commands/topics_write_test.js
+++ b/test/commands/topics_write_test.js
@@ -148,6 +148,30 @@ describe('kafka:topics:write', () => {
               })
   })
 
+  it('uses a prefixed topic if one is used', () => {
+    var withPrefixConfig = {}
+    Object.assign(withPrefixConfig, config)
+    withPrefixConfig.KAFKA_PREFIX = 'nile-1234.'
+    api.get('/apps/myapp/config-vars').reply(200, withPrefixConfig)
+    api.get('/apps/myapp/addon-attachments/kafka-1')
+      .reply(200, { name: 'KAFKA' })
+
+    producer.send = (payload) => {
+      expect(payload.topic).to.equal('nile-1234.topic-1')
+      expect(payload.partition).to.equal(0)
+      expect(payload.message).to.deep.equal({ value: 'hello world' })
+      return Promise.resolve()
+    }
+
+    return cmd.run({app: 'myapp',
+                    args: { TOPIC: 'nile-1234.topic-1', MESSAGE: 'hello world' },
+                    flags: {}})
+              .then(() => {
+                expect(cli.stdout).to.be.empty
+                expect(cli.stderr).to.be.empty
+              })
+  })
+
   it('uses given partition if specified', () => {
     api.get('/apps/myapp/config-vars').reply(200, config)
     api.get('/apps/myapp/addon-attachments/kafka-1')


### PR DESCRIPTION
This checks the CLI input against whether the addon has a prefix. If so, it will apply the prefix to the arguments passed to the endpoint. Additionally, we ensure that all outputs contain the prefixed argument. Builds on #142.

Tests are failing (for now). What is the feedback on this approach?