### PR TITLE
mix compaction and retention in topic info

### DIFF
--- a/commands/topics_info.js
+++ b/commands/topics_info.js
@@ -52,6 +52,8 @@ function topicInfo (topic) {
       name: 'Compaction',
       values: [`Compaction is disabled for ${topic.name}`]
     })
+  }
+  if (topic.retention_enabled) {
     lines.push({
       name: 'Retention',
       values: [retention(topic.retention_time_ms)]

--- a/test/commands/topics_info_test.js
+++ b/test/commands/topics_info_test.js
@@ -51,6 +51,7 @@ describe('kafka:topics:info', () => {
           replication_factor: 3,
           partitions: 3,
           compaction_enabled: false,
+          retention_enabled: true,
           retention_time_ms: 86400000
         }
       ]


### PR DESCRIPTION
when testing mixed compaction/retention (as of KIP-71), I found that we
don't display retention if compaction is enabled. The data API now
always returns `compaction_enabled` and `retention_enabled` as fields,
so we need to respect those.