### PR TITLE
show max topics limit in heroku kafka:info

### DIFF
--- a/commands/info.js
+++ b/commands/info.js
@@ -29,10 +29,17 @@ function formatInfo (info) {
 
   // we hide __consumer_offsets in topic listing; don't count it
   const topicCount = cluster.topics.filter((topic) => topic !== '__consumer_offsets').length
-  lines.push({
-    name: 'Topics',
-    values: [`${topicCount} ${humanize.pluralize(topicCount, 'topic')}, see heroku kafka:topics`]
-  })
+  if (cluster.limits && cluster.limits.max_topics) {
+    lines.push({
+      name: 'Topics',
+      values: [`${topicCount} / ${cluster.limits.max_topics} topics, see heroku kafka:topics`]
+    })
+  } else {
+    lines.push({
+      name: 'Topics',
+      values: [`${topicCount} ${humanize.pluralize(topicCount, 'topic')}, see heroku kafka:topics`]
+    })
+  }
 
   if (cluster.topic_prefix) {
     lines.push({ name: 'Prefix', values: [cluster.topic_prefix] })

--- a/test/commands/info_test.js
+++ b/test/commands/info_test.js
@@ -85,6 +85,7 @@ describe('kafka:info', () => {
       state: { message: 'available' },
       robot: { is_robot: false },
       topics: ['__consumer_offsets', 'messages'],
+      limits: {max_topics: 10},
       messages_in_per_sec: 0,
       bytes_in_per_sec: 0,
       bytes_out_per_sec: 0,
@@ -117,7 +118,7 @@ Plan:     heroku-kafka:beta-3
 Status:   available
 Version:  0.10.0.0
 Created:  2016-11-14T14:26:20.245+00:00
-Topics:   1 topic, see heroku kafka:topics
+Topics:   1 / 10 topics, see heroku kafka:topics
 Messages: 0 messages/s
 Traffic:  0 bytes/s in / 0 bytes/s out
 Add-on:   kafka-2
@@ -140,7 +141,7 @@ Plan:     heroku-kafka:beta-3
 Status:   available
 Version:  0.10.0.0
 Created:  2016-11-14T14:26:20.245+00:00
-Topics:   1 topic, see heroku kafka:topics
+Topics:   1 / 10 topics, see heroku kafka:topics
 Messages: 0 messages/s
 Traffic:  0 bytes/s in / 0 bytes/s out
 Add-on:   kafka-2
@@ -162,7 +163,7 @@ Plan:     heroku-kafka:beta-3
 Status:   available
 Version:  0.10.0.0
 Created:  2016-11-14T14:26:20.245+00:00
-Topics:   1 topic, see heroku kafka:topics
+Topics:   1 / 10 topics, see heroku kafka:topics
 Messages: 0 messages/s
 Traffic:  0 bytes/s in / 0 bytes/s out
 Add-on:   kafka-2


### PR DESCRIPTION
some clusters have a max number of topics. If there is one, display it
in the CLI output like so:

```
Topics:    0 / 10 topics, see heroku kafka:topics
```