### PR TITLE
show topic limits if they're there in kafka:topics

### DIFF
--- a/commands/topics.js
+++ b/commands/topics.js
@@ -15,6 +15,11 @@ function * listTopics (context, heroku) {
       path: `/data/kafka/${VERSION}/clusters/${addon.id}/topics`
     })
     cli.styledHeader('Kafka Topics on ' + (topics.attachment_name || 'HEROKU_KAFKA'))
+
+    if (topics.topics.length !== 0 && topics.limits && topics.limits.max_topics) {
+      cli.log(`${topics.topics.length} / ${topics.limits.max_topics} topics`)
+    }
+
     let filtered = topics.topics.filter((t) => t.name !== '__consumer_offsets')
     let topicData = filtered.map((t) => {
       return {
@@ -26,7 +31,12 @@ function * listTopics (context, heroku) {
     cli.log()
     if (topicData.length === 0) {
       cli.log('No topics found on this Kafka cluster.')
-      cli.log('Use heroku kafka:topics:create to create a topic.')
+
+      if (topics.limits && topics.limits.max_topics) {
+        cli.log(`Use heroku kafka:topics:create to create a topic (limit ${topics.limits.max_topics}).`)
+      } else {
+        cli.log('Use heroku kafka:topics:create to create a topic.')
+      }
     } else {
       cli.table(topicData,
         {

--- a/test/commands/topics_test.js
+++ b/test/commands/topics_test.js
@@ -43,6 +43,9 @@ describe('kafka:topics', () => {
     it('indicates there are no topics', () => {
       kafka.get(topicsUrl('00000000-0000-0000-0000-000000000000')).reply(200, {
         attachment_name: 'HEROKU_KAFKA_BLUE_URL',
+        limits: {
+          max_topics: 10
+        },
         topics: []
       })
 
@@ -50,7 +53,7 @@ describe('kafka:topics', () => {
         .then(() => expect(cli.stdout).to.equal(`=== Kafka Topics on HEROKU_KAFKA_BLUE_URL
 
 No topics found on this Kafka cluster.
-Use heroku kafka:topics:create to create a topic.
+Use heroku kafka:topics:create to create a topic (limit 10).
 `))
         .then(() => expect(cli.stderr).to.be.empty)
     })
@@ -80,11 +83,15 @@ Use heroku kafka:topics:create to create a topic.
         topics: [
           { name: 'topic-1', messages_in_per_second: 10.0, bytes_in_per_second: 0 },
           { name: 'topic-2', messages_in_per_second: 12.0, bytes_in_per_second: 3 }
-        ]
+        ],
+        limits: {
+          max_topics: 10
+        }
       })
 
       return cmd.run({app: 'myapp', args: {}})
         .then(() => expect(cli.stdout).to.equal(`=== Kafka Topics on HEROKU_KAFKA_BLUE_URL
+2 / 10 topics
 
 Name     Messages  Traffic
 ───────  ────────  ───────────


### PR DESCRIPTION
if there are topic limits on the addon, show them in `heroku kafka:topics`