### PR TITLE
Fix kafka:topics:compaction and kafka:topics:retention-time

### DIFF
--- a/commands/topics_compaction.js
+++ b/commands/topics_compaction.js
@@ -55,7 +55,10 @@ module.exports = {
   command: 'topics:compaction',
   description: 'configures topic compaction in Kafka',
   help: `
-    Enables or disables topic compaction in Kafka.
+    Enables or disables topic compaction in Kafka. If compaction is enabled on an add-on that
+    does not support compaction and time-based retention together, time-based retention is
+    automatically turned off. If compaction is disabled, time-based retention is required:
+    it is automatically set to the plan minimum.
 
     Examples:
 

--- a/commands/topics_create.js
+++ b/commands/topics_create.js
@@ -58,7 +58,8 @@ let cmd = {
   command: 'topics:create',
   description: 'creates a topic in Kafka',
   help: `
-    Creates a topic in Kafka.
+    Creates a topic in Kafka. Defaults to time-based retention according to plan
+    minimum if not explicitly specified.
 
     Examples:
 

--- a/commands/topics_create.js
+++ b/commands/topics_create.js
@@ -10,14 +10,13 @@ let request = require('../lib/clusters').request
 const VERSION = 'v0'
 
 function * createTopic (context, heroku) {
-  var flags = Object.assign({}, context.flags)
+  let flags = Object.assign({}, context.flags)
+  let retentiomTimeMillis
   if ('retention-time' in flags) {
-    let value = flags['retention-time']
-    let parsed = parseDuration(value)
+    let retentiomTimeMillis = parseDuration(flags['retention-time'])
     if (parsed == null) {
-      cli.exit(1, `Could not parse retention time '${value}'; expected value like '10d' or '36h'`)
+      cli.exit(1, `Could not parse retention time '${flags['retention-time']}'; expected value like '10d' or '36h'`)
     }
-    flags['retention-time'] = parsed
   }
 
   yield withCluster(heroku, context.app, context.args.CLUSTER, function * (addon) {
@@ -32,7 +31,7 @@ function * createTopic (context, heroku) {
         body: {
           topic: {
             name: context.args.TOPIC,
-            retention_time_ms: flags['retention-time'],
+            retention_time_ms: retentiomTimeMillis,
             replication_factor: flags['replication-factor'],
             partition_count: flags['partitions'],
             compaction: flags['compaction'] || false

--- a/commands/topics_create.js
+++ b/commands/topics_create.js
@@ -16,7 +16,7 @@ function * createTopic (context, heroku) {
   let retentionTimeMillis
   if ('retention-time' in flags) {
     retentionTimeMillis = parseDuration(flags['retention-time'])
-    if (retentionTimeMillis == null) {
+    if (!retentionTimeMillis) {
       cli.exit(1, `Could not parse retention time '${flags['retention-time']}'; expected value like '10d' or '36h'`)
     }
   }
@@ -25,12 +25,12 @@ function * createTopic (context, heroku) {
   yield withCluster(heroku, context.app, context.args.CLUSTER, function * (addon) {
     let addonInfo = yield fetchProvisionedInfo(heroku, addon)
 
-    if ((!compaction || addonInfo.shared_cluster) && retentionTimeMillis === undefined) {
+    if ((!compaction || addonInfo.shared_cluster) && !retentionTimeMillis) {
       retentionTimeMillis = addonInfo.limits.minimum_retention_ms
     }
 
     let msg = `Creating topic ${context.args.TOPIC} with compaction ${compaction ? 'enabled' : 'disabled'}`
-    if (retentionTimeMillis !== undefined) {
+    if (retentionTimeMillis) {
       msg += ` and retention time ${formatIntervalFromMilliseconds(retentionTimeMillis)}`
     }
     msg += ` on ${addon.name}`

--- a/commands/topics_info.js
+++ b/commands/topics_info.js
@@ -41,7 +41,7 @@ function topicInfo (topic) {
     }
   ]
 
-  if (topic.compaction_enabled) {
+  if (topic.compaction) {
     lines.push({
       name: 'Compaction',
       values: [`Compaction is enabled for ${topic.name}`]
@@ -52,7 +52,7 @@ function topicInfo (topic) {
       values: [`Compaction is disabled for ${topic.name}`]
     })
   }
-  if (topic.retention_enabled) {
+  if (topic.retention_time_ms) {
     lines.push({
       name: 'Retention',
       values: [retention(topic.retention_time_ms)]

--- a/commands/topics_info.js
+++ b/commands/topics_info.js
@@ -5,10 +5,8 @@ let co = require('co')
 let humanize = require('humanize-plus')
 let deprecated = require('../lib/shared').deprecated
 let withCluster = require('../lib/clusters').withCluster
-let request = require('../lib/clusters').request
 let topicConfig = require('../lib/clusters').topicConfig
 
-const VERSION = 'v0'
 const ONE_HOUR_IN_MS = 60 * 60 * 1000
 const TWENTY_FOUR_HOURS_IN_MS = ONE_HOUR_IN_MS * 24
 const TWO_DAYS_IN_MS = TWENTY_FOUR_HOURS_IN_MS * 2
@@ -66,11 +64,12 @@ function topicInfo (topic) {
 
 function * kafkaTopic (context, heroku) {
   yield withCluster(heroku, context.app, context.args.CLUSTER, function * (addon) {
-    let topic = yield topicConfig(heroku, addon.id, context.args.TOPIC)
+    let topicName = context.args.TOPIC
+    let topic = yield topicConfig(heroku, addon.id, topicName)
     if (topic.partitions < 1) {
-      cli.exit(1, `topic ${topic} is not available yet`)
+      cli.exit(1, `topic ${topicName} is not available yet`)
     } else {
-      cli.styledHeader(addon.name + ' :: ' + context.args.TOPIC)
+      cli.styledHeader(addon.name + ' :: ' + topicName)
       cli.log()
       cli.styledNameValues(topicInfo(topic))
     }

--- a/commands/topics_retention_time.js
+++ b/commands/topics_retention_time.js
@@ -53,13 +53,17 @@ function * retentionTime (context, heroku) {
 module.exports = {
   topic: 'kafka',
   command: 'topics:retention-time',
-  description: 'configures topic retention time (e.g. 10d, 36h)',
+  description: 'configures or disables topic retention time (e.g. 10d, 36h)',
   help: `
-    Configures topic retention time in Kafka.
+    Configures or disables topic retention time in Kafka. If disabling, compaction is
+    required and is automatically turned on. If time-based retention is enabled on an
+    add-on that does not support compaction and time-based retention together, compaction
+    is automatically turned off. Time-based retention cannot be disabled on multi-tenant plans.
 
     Examples:
 
   $ heroku kafka:topics:retention-time page-visits 10d
+  $ heroku kafka:topics:retention-time page-visits disable
   $ heroku kafka:topics:retention-time page-visits 36h HEROKU_KAFKA_BROWN_URL
   `,
   needsApp: true,

--- a/commands/topics_retention_time.js
+++ b/commands/topics_retention_time.js
@@ -33,7 +33,7 @@ function * retentionTime (context, heroku) {
     ]
     let cleanupPolicy = {
       retention_time_ms: parsed,
-      compaction: (!parsed || (addonInfo.capabilities.supports_mixed_cleanup_policy && topicInfo.compaction_enabled))
+      compaction: (!parsed || (addonInfo.capabilities.supports_mixed_cleanup_policy && topicInfo.compaction))
     }
 
     yield cli.action(msg, co(function * () {

--- a/commands/topics_retention_time.js
+++ b/commands/topics_retention_time.js
@@ -11,12 +11,10 @@ let fetchProvisionedInfo = require('../lib/clusters').fetchProvisionedInfo
 const VERSION = 'v0'
 
 function * retentionTime (context, heroku) {
-  let parsed
-  if (context.args.VALUE === 'disable') {
-    parsed = null
-  } else {
+  let parsed = null
+  if (context.args.VALUE !== 'disable') {
     parsed = parseDuration(context.args.VALUE)
-    if (parsed == null) {
+    if (!parsed) {
       cli.exit(1, `Unknown retention time '${context.args.VALUE}'; expected 'disable' or value like '36h' or '10d'`)
     }
   }
@@ -33,7 +31,7 @@ function * retentionTime (context, heroku) {
     }
 
     let msg
-    if (parsed == null) {
+    if (!parsed) {
       msg = 'Disabling time-based retention'
       if (cleanupPolicy.compaction !== topicInfo.compaction) {
         msg += ` and ${cleanupPolicy.compaction ? 'enabling' : 'disabling'} compaction`

--- a/lib/clusters.js
+++ b/lib/clusters.js
@@ -67,6 +67,17 @@ function * withCluster (heroku, app, cluster, fn) {
   yield * fn(addon)
 }
 
+function * topicConfig (heroku, addonId, topic) {
+  let info = yield request(heroku, {
+    path: `/data/kafka/${VERSION}/clusters/${addonId}/topics`
+  })
+  let forTopic = info.topics.find((t) => t.name === topic)
+  if (!forTopic) {
+    cli.exit(1, `topic ${topic} not found`)
+  }
+  return forTopic
+}
+
 function request (heroku, params) {
   const h = host()
   debug(`picked shogun host: ${h}`)
@@ -80,5 +91,6 @@ function request (heroku, params) {
 module.exports = {
   HerokuKafkaClusters: HerokuKafkaClusters,
   withCluster,
-  request
+  request,
+  topicConfig
 }

--- a/lib/clusters.js
+++ b/lib/clusters.js
@@ -78,6 +78,18 @@ function * topicConfig (heroku, addonId, topic) {
   return forTopic
 }
 
+// Fetch kafka info about a provisioned cluster or exit with failure
+function fetchProvisionedInfo (heroku, addon) {
+  return heroku.request({
+    host: host(addon),
+    method: 'get',
+    path: `/data/kafka/v0/clusters/${addon.id}`
+  }).catch(err => {
+    if (err.statusCode !== 404) throw err
+    cli.exit(1, `${cli.color.addon(addon.name)} is not yet provisioned.\nRun ${cli.color.cmd('heroku kafka:wait')} to wait until the cluster is provisioned.`)
+  })
+}
+
 function request (heroku, params) {
   const h = host()
   debug(`picked shogun host: ${h}`)
@@ -92,5 +104,6 @@ module.exports = {
   HerokuKafkaClusters: HerokuKafkaClusters,
   withCluster,
   request,
-  topicConfig
+  topicConfig,
+  fetchProvisionedInfo
 }

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -88,10 +88,47 @@ function parseDuration (durationStr) {
   }
 }
 
+function formatIntervalFromMilliseconds (milliseconds) {
+  let remaining = milliseconds
+  let multipliers = {
+    day: (24 * 60 * 60 * 1000),
+    hour: (60 * 60 * 1000),
+    minute: (60 * 1000),
+    second: 1000
+  }
+  let intervals = Object.keys(multipliers).sort((interval) => -multipliers[interval])
+  let values = intervals.reduce((accum, interval) => { accum[interval] = 0; return accum }, {})
+  let smallest = multipliers[intervals[intervals.length - 1]]
+
+  while (remaining >= smallest) {
+    let nextInterval = intervals.find((interval) => {
+      return multipliers[interval] <= remaining
+    })
+    let nextIntervalValue = multipliers[nextInterval]
+    let multiplier = 1
+
+    while ((nextIntervalValue * (multiplier + 1)) <= remaining) {
+      multiplier += 1
+    }
+
+    values[nextInterval] = multiplier
+    remaining -= nextIntervalValue * multiplier
+  }
+
+  values.millisecond = remaining
+  intervals.push('millisecond')
+
+  return intervals.filter((interval) => values[interval] > 0).map((interval) => {
+    let val = values[interval]
+    return `${val} ${interval}${val > 1 ? 's' : ''}`
+  }).join(' ')
+}
+
 module.exports = {
   clusterConfig,
   deprecated,
   parseBool,
   parseDuration,
-  isPrivate
+  isPrivate,
+  formatIntervalFromMilliseconds
 }

--- a/test/commands/topics_compaction_test.js
+++ b/test/commands/topics_compaction_test.js
@@ -29,6 +29,14 @@ describe('kafka:topics:compaction', () => {
     return `/data/kafka/v0/clusters/${cluster}/topics/${topic}`
   }
 
+  let topicListUrl = (cluster) => {
+    return `/data/kafka/v0/clusters/${cluster}/topics`
+  }
+
+  let infoUrl = (cluster) => {
+    return `/data/kafka/v0/clusters/${cluster}`
+  }
+
   beforeEach(() => {
     kafka = nock('https://kafka-api.heroku.com:443')
     cli.mockConsole()
@@ -52,26 +60,77 @@ describe('kafka:topics:compaction', () => {
   })
 
   const validEnable = [ 'enable', 'on' ]
-  validEnable.forEach((value) => {
-    it(`turns compaction on with argument ${value}`, () => {
-      kafka.put(topicConfigUrl('00000000-0000-0000-0000-000000000000', 'topic-1'),
-                { topic: { name: 'topic-1', compaction: true } }).reply(200)
+  const validDisable = [ 'disable', 'off' ]
 
-      return cmd.run({app: 'myapp', args: { TOPIC: 'topic-1', VALUE: value }})
-                .then(() => expect(cli.stderr).to.equal('Enabling compaction for topic topic-1... done\n'))
-                .then(() => expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n'))
+  describe('if the cluster supports a mixed cleanup policy', () => {
+    beforeEach(() => {
+      kafka.get(topicListUrl('00000000-0000-0000-0000-000000000000'))
+           .reply(200, { topics: [ { name: 'topic-1', retention_time_ms: 123 } ] })
+      kafka.get(infoUrl('00000000-0000-0000-0000-000000000000'))
+           .reply(200, {
+             capabilities: { supports_mixed_cleanup_policy: true },
+             limits: { minimum_retention_ms: 20 }
+           })
+    })
+
+    validEnable.forEach((value) => {
+      it(`uses the original retention and turns compaction on with argument ${value}`, () => {
+        kafka.put(topicConfigUrl('00000000-0000-0000-0000-000000000000', 'topic-1'),
+                  { topic: { name: 'topic-1', compaction: true, retention_time_ms: 123 } })
+             .reply(200)
+
+        return cmd.run({app: 'myapp', args: { TOPIC: 'topic-1', VALUE: value }})
+                  .then(() => expect(cli.stderr).to.equal('Enabling compaction for topic topic-1... done\n'))
+                  .then(() => expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n'))
+      })
+    })
+
+    validDisable.forEach((value) => {
+      it(`turns compaction off and sets retention to plan minimum with argument ${value}`, () => {
+        kafka.put(topicConfigUrl('00000000-0000-0000-0000-000000000000', 'topic-1'),
+                  { topic: { name: 'topic-1', compaction: false, retention_time_ms: 20 } })
+             .reply(200)
+
+        return cmd.run({app: 'myapp', args: { TOPIC: 'topic-1', VALUE: value }})
+                  .then(() => expect(cli.stderr).to.equal('Disabling compaction for topic topic-1... done\n'))
+                  .then(() => expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n'))
+      })
     })
   })
 
-  const validDisable = [ 'disable', 'off' ]
-  validDisable.forEach((value) => {
-    it(`turns compaction off with argument ${value}`, () => {
-      kafka.put(topicConfigUrl('00000000-0000-0000-0000-000000000000', 'topic-1'),
-                { topic: { name: 'topic-1', compaction: false } }).reply(200)
+  describe('if the cluster does not support a mixed cleanup policy', () => {
+    beforeEach(() => {
+      kafka.get(topicListUrl('00000000-0000-0000-0000-000000000000'))
+           .reply(200, { topics: [ { name: 'topic-1', retention_time_ms: 123 } ] })
+      kafka.get(infoUrl('00000000-0000-0000-0000-000000000000'))
+           .reply(200, {
+             capabilities: { supports_mixed_cleanup_policy: false },
+             limits: { minimum_retention_ms: 20 }
+           })
+    })
 
-      return cmd.run({app: 'myapp', args: { TOPIC: 'topic-1', VALUE: value }})
-                .then(() => expect(cli.stderr).to.equal('Disabling compaction for topic topic-1... done\n'))
-                .then(() => expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n'))
+    validEnable.forEach((value) => {
+      it(`turns off retention and turns compaction on with argument ${value}`, () => {
+        kafka.put(topicConfigUrl('00000000-0000-0000-0000-000000000000', 'topic-1'),
+                  { topic: { name: 'topic-1', compaction: true, retention_time_ms: null } })
+             .reply(200)
+
+        return cmd.run({app: 'myapp', args: { TOPIC: 'topic-1', VALUE: value }})
+                  .then(() => expect(cli.stderr).to.equal('Enabling compaction for topic topic-1... done\n'))
+                  .then(() => expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n'))
+      })
+    })
+
+    validDisable.forEach((value) => {
+      it(`turns compaction off and sets retention to plan minimum with argument ${value}`, () => {
+        kafka.put(topicConfigUrl('00000000-0000-0000-0000-000000000000', 'topic-1'),
+                  { topic: { name: 'topic-1', compaction: false, retention_time_ms: 20 } })
+             .reply(200)
+
+        return cmd.run({app: 'myapp', args: { TOPIC: 'topic-1', VALUE: value }})
+                  .then(() => expect(cli.stderr).to.equal('Disabling compaction for topic topic-1... done\n'))
+                  .then(() => expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n'))
+      })
     })
   })
 })

--- a/test/commands/topics_create_test.js
+++ b/test/commands/topics_create_test.js
@@ -73,7 +73,7 @@ describe('kafka:topics:create', () => {
                              'retention-time': '10ms',
                              'partitions': '7' }})
               .then(() => {
-                expect(cli.stderr).to.equal('Creating topic topic-1... done\n')
+                expect(cli.stderr).to.equal('Creating topic topic-1 with compaction disabled and retention time 10 milliseconds on kafka-1... done\n')
                 expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n')
               })
   })
@@ -97,7 +97,7 @@ describe('kafka:topics:create', () => {
                     flags: { 'replication-factor': '3',
                              'partitions': '7' }})
               .then(() => {
-                expect(cli.stderr).to.equal('Creating topic topic-1... done\n')
+                expect(cli.stderr).to.equal('Creating topic topic-1 with compaction disabled and retention time 66 milliseconds on kafka-1... done\n')
                 expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n')
               })
   })
@@ -123,7 +123,7 @@ describe('kafka:topics:create', () => {
                                'partitions': '7',
                                'compaction': true }})
                 .then(() => {
-                  expect(cli.stderr).to.equal('Creating topic topic-1... done\n')
+                  expect(cli.stderr).to.equal('Creating topic topic-1 with compaction enabled and retention time 66 milliseconds on kafka-1... done\n')
                   expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n')
                 })
     })

--- a/test/commands/topics_info_test.js
+++ b/test/commands/topics_info_test.js
@@ -59,7 +59,7 @@ describe('kafka:topics:info', () => {
     })
 
     return cmd.run({app: 'myapp', args: { TOPIC: 'topic-1' }})
-      .then(() => expect(cli.stdout).to.equal(`=== HEROKU_KAFKA_BLUE_URL :: topic-1
+      .then(() => expect(cli.stdout).to.equal(`=== kafka-1 :: topic-1
 
 Producers:          0 messages/second (0 bytes/second) total
 Consumers:          0 bytes/second total

--- a/test/commands/topics_info_test.js
+++ b/test/commands/topics_info_test.js
@@ -51,8 +51,7 @@ describe('kafka:topics:info', () => {
           bytes_out_per_second: 0,
           replication_factor: 3,
           partitions: 3,
-          compaction_enabled: false,
-          retention_enabled: true,
+          compaction: false,
           retention_time_ms: 86400000
         }
       ]
@@ -82,7 +81,7 @@ Retention:          24 hours
           bytes_out_per_second: 0,
           replication_factor: 0,
           partitions: 0,
-          compaction_enabled: false,
+          compaction: false,
           retention_time_ms: 86400000
         }
       ]
@@ -104,7 +103,7 @@ Retention:          24 hours
           bytes_out_per_second: 0,
           replication_factor: 0,
           partitions: 0,
-          compaction_enabled: false,
+          compaction: false,
           retention_time_ms: 86400000
         }
       ]

--- a/test/commands/topics_replication_factor_test.js
+++ b/test/commands/topics_replication_factor_test.js
@@ -24,6 +24,10 @@ const cmd = proxyquire('../../commands/topics_replication_factor', {
 describe('kafka:topics:replication-factor', () => {
   let kafka
 
+  let topicListUrl = (cluster) => {
+    return `/data/kafka/v0/clusters/${cluster}/topics`
+  }
+
   let topicConfigUrl = (cluster, topic) => {
     return `/data/kafka/v0/clusters/${cluster}/topics/${topic}`
   }
@@ -40,8 +44,11 @@ describe('kafka:topics:replication-factor', () => {
   })
 
   it('sets replication factor to the specified value', () => {
+    kafka.get(topicListUrl('00000000-0000-0000-0000-000000000000'))
+         .reply(200, { topics: [ { name: 'topic-1', retention_time_ms: 123, compaction: true } ] })
     kafka.put(topicConfigUrl('00000000-0000-0000-0000-000000000000', 'topic-1'),
-              { topic: { name: 'topic-1', replication_factor: '5' } }).reply(200)
+              { topic: { name: 'topic-1', replication_factor: '5', retention_time_ms: 123, compaction: true } })
+         .reply(200)
 
     return cmd.run({app: 'myapp', args: { TOPIC: 'topic-1', VALUE: '5' }})
               .then(() => expect(cli.stderr).to.equal('Setting replication factor for topic topic-1 to 5... done\n'))

--- a/test/commands/topics_retention_time_test.js
+++ b/test/commands/topics_retention_time_test.js
@@ -82,7 +82,7 @@ describe('kafka:topics:retention-time', () => {
                 .then(() => expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n'))
     })
 
-    it('clears retention and turns on compaction if `disabled` is specified', () => {
+    it('clears retention and turns on compaction if `disable` is specified', () => {
       kafka.put(topicConfigUrl('00000000-0000-0000-0000-000000000000', 'topic-1'),
                 { topic: { name: 'topic-1', retention_time_ms: null, compaction: true } }).reply(200)
 

--- a/test/commands/topics_retention_time_test.js
+++ b/test/commands/topics_retention_time_test.js
@@ -63,7 +63,7 @@ describe('kafka:topics:retention-time', () => {
   describe('if the cluster supports a mixed cleanup policy', () => {
     beforeEach(() => {
       kafka.get(topicListUrl('00000000-0000-0000-0000-000000000000'))
-           .reply(200, { topics: [ { name: 'topic-1', retention_time_ms: 123, compaction_enabled: false } ] })
+           .reply(200, { topics: [ { name: 'topic-1', retention_time_ms: 123, compaction: false } ] })
       kafka.get(infoUrl('00000000-0000-0000-0000-000000000000'))
            .reply(200, {
              capabilities: { supports_mixed_cleanup_policy: true },
@@ -97,7 +97,7 @@ describe('kafka:topics:retention-time', () => {
   describe('if the cluster does not support a mixed cleanup policy', () => {
     beforeEach(() => {
       kafka.get(topicListUrl('00000000-0000-0000-0000-000000000000'))
-           .reply(200, { topics: [ { name: 'topic-1', retention_time_ms: 123, compaction_enabled: true } ] })
+           .reply(200, { topics: [ { name: 'topic-1', retention_time_ms: 123, compaction: true } ] })
       kafka.get(infoUrl('00000000-0000-0000-0000-000000000000'))
            .reply(200, {
              capabilities: { supports_mixed_cleanup_policy: false },

--- a/test/commands/topics_retention_time_test.js
+++ b/test/commands/topics_retention_time_test.js
@@ -78,7 +78,7 @@ describe('kafka:topics:retention-time', () => {
       return cmd.run({app: 'myapp',
                       args: { TOPIC: 'topic-1', VALUE: '60s' },
                       flags: {}})
-                .then(() => expect(cli.stderr).to.equal('Setting retention time for topic topic-1 to 60s... done\n'))
+                .then(() => expect(cli.stderr).to.equal('Setting retention time to 60s for topic topic-1 on kafka-1... done\n'))
                 .then(() => expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n'))
     })
 
@@ -89,7 +89,7 @@ describe('kafka:topics:retention-time', () => {
       return cmd.run({app: 'myapp',
                       args: { TOPIC: 'topic-1', VALUE: 'disable' },
                       flags: {}})
-                .then(() => expect(cli.stderr).to.equal('Setting retention time for topic topic-1 to disable... done\n'))
+                .then(() => expect(cli.stderr).to.equal('Disabling time-based retention and enabling compaction for topic topic-1 on kafka-1... done\n'))
                 .then(() => expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n'))
     })
   })
@@ -112,7 +112,7 @@ describe('kafka:topics:retention-time', () => {
       return cmd.run({app: 'myapp',
                       args: { TOPIC: 'topic-1', VALUE: '60s' },
                       flags: {}})
-                .then(() => expect(cli.stderr).to.equal('Setting retention time for topic topic-1 to 60s... done\n'))
+                .then(() => expect(cli.stderr).to.equal('Setting retention time to 60s and disabling compaction for topic topic-1 on kafka-1... done\n'))
                 .then(() => expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n'))
     })
 
@@ -123,7 +123,7 @@ describe('kafka:topics:retention-time', () => {
       return cmd.run({app: 'myapp',
                       args: { TOPIC: 'topic-1', VALUE: 'disable' },
                       flags: {}})
-                .then(() => expect(cli.stderr).to.equal('Setting retention time for topic topic-1 to disable... done\n'))
+                .then(() => expect(cli.stderr).to.equal('Disabling time-based retention for topic topic-1 on kafka-1... done\n'))
                 .then(() => expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n'))
     })
   })

--- a/test/commands/topics_retention_time_test.js
+++ b/test/commands/topics_retention_time_test.js
@@ -29,6 +29,14 @@ describe('kafka:topics:retention-time', () => {
     return `/data/kafka/v0/clusters/${cluster}/topics/${topic}`
   }
 
+  let topicListUrl = (cluster) => {
+    return `/data/kafka/v0/clusters/${cluster}/topics`
+  }
+
+  let infoUrl = (cluster) => {
+    return `/data/kafka/v0/clusters/${cluster}`
+  }
+
   beforeEach(() => {
     kafka = nock('https://kafka-api.heroku.com:443')
     cli.mockConsole()
@@ -46,18 +54,77 @@ describe('kafka:topics:retention-time', () => {
                                     args: { TOPIC: 'topic-1', VALUE: '1 fortnight' },
                                     flags: {}}))
         .then(() => expect(cli.stdout).to.be.empty)
-        .then(() => expect(cli.stderr).to.equal(` ▸    Unknown retention time '1 fortnight'; expected value like '36h' or '10d'\n`))
+        .then(() => expect(cli.stderr).to.equal(` ▸    Unknown retention time '1 fortnight'; expected 'disable' or value like
+ ▸    '36h' or '10d'
+`))
     })
   })
 
-  it('sets retention time to the specified value', () => {
-    kafka.put(topicConfigUrl('00000000-0000-0000-0000-000000000000', 'topic-1'),
-              { topic: { name: 'topic-1', retention_time_ms: 60000 } }).reply(200)
+  describe('if the cluster supports a mixed cleanup policy', () => {
+    beforeEach(() => {
+      kafka.get(topicListUrl('00000000-0000-0000-0000-000000000000'))
+           .reply(200, { topics: [ { name: 'topic-1', retention_time_ms: 123, compaction_enabled: false } ] })
+      kafka.get(infoUrl('00000000-0000-0000-0000-000000000000'))
+           .reply(200, {
+             capabilities: { supports_mixed_cleanup_policy: true },
+             limits: { minimum_retention_ms: 20 }
+           })
+    })
 
-    return cmd.run({app: 'myapp',
-                    args: { TOPIC: 'topic-1', VALUE: '60s' },
-                    flags: {}})
-              .then(() => expect(cli.stderr).to.equal('Setting retention time for topic topic-1 to 60s... done\n'))
-              .then(() => expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n'))
+    it('sets retention time and leaves compaction as is if a value is specified', () => {
+      kafka.put(topicConfigUrl('00000000-0000-0000-0000-000000000000', 'topic-1'),
+                { topic: { name: 'topic-1', retention_time_ms: 60000, compaction: false } }).reply(200)
+
+      return cmd.run({app: 'myapp',
+                      args: { TOPIC: 'topic-1', VALUE: '60s' },
+                      flags: {}})
+                .then(() => expect(cli.stderr).to.equal('Setting retention time for topic topic-1 to 60s... done\n'))
+                .then(() => expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n'))
+    })
+
+    it('clears retention and turns on compaction if `disabled` is specified', () => {
+      kafka.put(topicConfigUrl('00000000-0000-0000-0000-000000000000', 'topic-1'),
+                { topic: { name: 'topic-1', retention_time_ms: null, compaction: true } }).reply(200)
+
+      return cmd.run({app: 'myapp',
+                      args: { TOPIC: 'topic-1', VALUE: 'disable' },
+                      flags: {}})
+                .then(() => expect(cli.stderr).to.equal('Setting retention time for topic topic-1 to disable... done\n'))
+                .then(() => expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n'))
+    })
+  })
+
+  describe('if the cluster does not support a mixed cleanup policy', () => {
+    beforeEach(() => {
+      kafka.get(topicListUrl('00000000-0000-0000-0000-000000000000'))
+           .reply(200, { topics: [ { name: 'topic-1', retention_time_ms: 123, compaction_enabled: true } ] })
+      kafka.get(infoUrl('00000000-0000-0000-0000-000000000000'))
+           .reply(200, {
+             capabilities: { supports_mixed_cleanup_policy: false },
+             limits: { minimum_retention_ms: 20 }
+           })
+    })
+
+    it('sets retention time and turns off compaction if a value is specified', () => {
+      kafka.put(topicConfigUrl('00000000-0000-0000-0000-000000000000', 'topic-1'),
+                { topic: { name: 'topic-1', retention_time_ms: 60000, compaction: false } }).reply(200)
+
+      return cmd.run({app: 'myapp',
+                      args: { TOPIC: 'topic-1', VALUE: '60s' },
+                      flags: {}})
+                .then(() => expect(cli.stderr).to.equal('Setting retention time for topic topic-1 to 60s... done\n'))
+                .then(() => expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n'))
+    })
+
+    it('clears retention and turns on compaction if `disabled` is specified', () => {
+      kafka.put(topicConfigUrl('00000000-0000-0000-0000-000000000000', 'topic-1'),
+                { topic: { name: 'topic-1', retention_time_ms: null, compaction: true } }).reply(200)
+
+      return cmd.run({app: 'myapp',
+                      args: { TOPIC: 'topic-1', VALUE: 'disable' },
+                      flags: {}})
+                .then(() => expect(cli.stderr).to.equal('Setting retention time for topic topic-1 to disable... done\n'))
+                .then(() => expect(cli.stdout).to.equal('Use `heroku kafka:topics:info topic-1` to monitor your topic.\n'))
+    })
   })
 })

--- a/test/lib/shared_test.js
+++ b/test/lib/shared_test.js
@@ -127,3 +127,29 @@ describe('deprecated', function () {
     expect(cli.stderr).to.match(/ ▸\s*WARNING: bar:foo is deprecated; please use bar:new-command/m)
   })
 })
+
+describe('formatIntervalFromMilliseconds', function () {
+  let cases = [
+    [ 10, '10 milliseconds' ],
+    [ 999, '999 milliseconds' ],
+    [ 1000, '1 second' ],
+    [ (10 * 1000 + 10), '10 seconds 10 milliseconds' ],
+    [ (10 * 60 * 1000 + 10), '10 minutes 10 milliseconds' ],
+    [ (10 * 60 * 1000 + 10 * 1000 + 10), '10 minutes 10 seconds 10 milliseconds' ],
+    [ (10 * 60 * 1000 + 10 * 1000), '10 minutes 10 seconds' ],
+    [ (20 * 60 * 60 * 1000 + 10 * 60 * 1000 + 10 * 1000), '20 hours 10 minutes 10 seconds' ],
+    [ (3 * 24 * 60 * 60 * 1000 + 10 * 60 * 1000 + 10 * 1000), '3 days 10 minutes 10 seconds' ],
+    [ (3 * 24 * 60 * 60 * 1000 + 10), '3 days 10 milliseconds' ],
+    [ (1 * 24 * 60 * 60 * 1000 + 1), '1 day 1 millisecond' ]
+  ]
+
+  cases.forEach(function (testcase) {
+    let duration = testcase[0]
+    let expected = testcase[1]
+
+    it(`formats ${duration} milliseconds as '${expected}'`, function () {
+      let actual = shared.formatIntervalFromMilliseconds(duration)
+      expect(actual).to.equal(expected)
+    })
+  })
+})


### PR DESCRIPTION
This aligns the CLI usage of the PUT `.../topics/:name` endpoint to what @halorgium and I discussed.

 - [x] update `kafka:topics:retention-time`
 - [x] update `kafka:topics:compaction`
 - [x] update `kafka:topics:create` to always send `retention_time_ms` based on plan minimum for MT
 - [x] update `kafka:topics:create` to always send `retention_time_ms` based on plan minimum when compaction is not enabled and retention is not specified
 - [x] update `kafka:topics:replication-factor` to pass back in existing `compaction` and `retention_time_ms`
 - [x] ensure we are using `compaction` and `retention_time_ms` in the topic output info (rather than `compaction_enabled` and `retention_enabled`)
   - [x] in `kafka:topics:info`
   - [x] in `kafka:topics:compaction`
   - [x] in `kafka:topics:retention-time`
 - [x] expand help text to document behavior
 - [x] expand topic change and creation confirmation messages, telling you full exact configuration effected by your change