### PR TITLE
catch 400 in kafka consumer group creation

### DIFF
--- a/commands/consumer_groups_create.js
+++ b/commands/consumer_groups_create.js
@@ -24,15 +24,15 @@ function * createConsumerGroup (context, heroku) {
           }
         },
         path: `/data/kafka/${VERSION}/clusters/${addon.id}/consumer_groups`
-      }).catch(err => {
-        if (err.statusCode === 400 && err.body.message === 'this command is not required or enabled on dedicated clusters') {
-          created = false
-          cli.warn(`${cli.color.addon(addon.name)} does not need consumer groups managed explicitly, so this command does nothing`)
-        } else {
-          throw err
-        }
       })
-    }))
+    })).catch(err => {
+      if (err.statusCode === 400 && err.body.message === 'this command is not required or enabled on dedicated clusters') {
+        created = false
+        cli.warn(`${cli.color.addon(addon.name)} does not need consumer groups managed explicitly, so this command does nothing`)
+      } else {
+        throw err
+      }
+    })
 
     if (created === true) {
       cli.log('Use `heroku kafka:consumer-groups` to list your consumer groups.')

--- a/commands/consumer_groups_create.js
+++ b/commands/consumer_groups_create.js
@@ -13,6 +13,7 @@ function * createConsumerGroup (context, heroku) {
     if (context.args.CLUSTER) {
       msg += ` on ${context.args.CLUSTER}`
     }
+    var created = true
 
     yield cli.action(msg, co(function * () {
       return yield request(heroku, {
@@ -23,10 +24,19 @@ function * createConsumerGroup (context, heroku) {
           }
         },
         path: `/data/kafka/${VERSION}/clusters/${addon.id}/consumer_groups`
+      }).catch(err => {
+        if (err.statusCode === 400 && err.body.message === 'this command is not required or enabled on dedicated clusters') {
+          created = false
+          cli.warn(`${cli.color.addon(addon.name)} does not need consumer groups managed explicitly, so this command does nothing`)
+        } else {
+          throw err
+        }
       })
     }))
 
-    cli.log('Use `heroku kafka:consumer-groups` to list your consumer groups.')
+    if (created === true) {
+      cli.log('Use `heroku kafka:consumer-groups` to list your consumer groups.')
+    }
   })
 }
 

--- a/test/commands/consumer_groups_create_test.js
+++ b/test/commands/consumer_groups_create_test.js
@@ -56,4 +56,20 @@ describe('kafka:consumer-groups:create', () => {
         expect(cli.stdout).to.equal('Use `heroku kafka:consumer-groups` to list your consumer groups.\n')
       })
   })
+
+  it("doesn't raise when the api 400s", () => {
+    kafka.post(consumerGroupsUrl('00000000-0000-0000-0000-000000000000'),
+      {
+        consumer_group: {
+          name: 'consumer-group-1'
+        }
+      }
+    ).reply(400, {message: 'this command is not required or enabled on dedicated clusters'})
+
+    return cmd.run({app: 'myapp',
+                  args: { CONSUMER_GROUP: 'consumer-group-1' }})
+      .then(() => {
+        expect(cli.stderr).to.equal(`Creating consumer group consumer-group-1... !\n ▸    kafka-1 does not need consumer groups managed explicitly, so this command\n ▸    does nothing\n`)
+      })
+  })
 })


### PR DESCRIPTION
this 400 is because kafka consumer group creation doesn't need to happen
on clusters that have enough credentials to use any consumer group. We
don't need to error here

sample output:

```
$ heroku kafka:consumer-groups:create greetings; echo $?
Creating consumer group greetings... done
 ▸    kafka-REDACTED-36649 does not need consumer groups managed explicitly, so this command does nothing
0
```