### PR TITLE
Avoid using the 'in' operator to check for presence of flags

### DIFF
--- a/commands/configure.js
+++ b/commands/configure.js
@@ -13,7 +13,7 @@ function * configureTopic (context, heroku) {
   }
 
   var flags = Object.assign({}, context.flags)
-  if ('retention-time' in flags) {
+  if (flags['retention-time'] !== undefined) {
     let value = flags['retention-time']
     let parsed = parseDuration(value)
     if (parsed == null) {
@@ -21,7 +21,7 @@ function * configureTopic (context, heroku) {
     }
     flags['retention-time'] = parsed
   }
-  if ('no-compaction' in flags) {
+  if (flags['no-compaction'] !== undefined) {
     flags['compaction'] = false
     delete flags['no-compaction']
   }

--- a/commands/topics_create.js
+++ b/commands/topics_create.js
@@ -14,7 +14,7 @@ const VERSION = 'v0'
 function * createTopic (context, heroku) {
   let flags = Object.assign({}, context.flags)
   let retentionTimeMillis
-  if ('retention-time' in flags) {
+  if (flags['retention-time'] !== undefined) {
     retentionTimeMillis = parseDuration(flags['retention-time'])
     if (!retentionTimeMillis) {
       cli.exit(1, `Could not parse retention time '${flags['retention-time']}'; expected value like '10d' or '36h'`)


### PR DESCRIPTION
CLI v5 only sends the flags the user passed in on the flags object,
but CLI v6 sends in all defined flags, with values of `undefined` for
ones not explicitly set. Since `'a' in { a: undefined }` is true,
change these to use an explicit check against `undefined` instead.

Fixes #159