### PR TITLE
Make kafka:credentials --reset flag required

### DIFF
--- a/commands/credentials_rotate.js
+++ b/commands/credentials_rotate.js
@@ -8,6 +8,10 @@ let request = require('../lib/clusters').request
 const VERSION = 'v0'
 
 function * credentialsRotate (context, heroku) {
+  if (!context.flags.reset) {
+    throw new Error('The --reset flag is required for this command')
+  }
+
   yield withCluster(heroku, context.app, context.args.CLUSTER, function * (addon) {
     let response = yield request(heroku, {
       method: 'POST',

--- a/test/commands/credentials_rotate_test.js
+++ b/test/commands/credentials_rotate_test.js
@@ -1,7 +1,13 @@
 'use strict'
 /* eslint standard/no-callback-literal: off, no-unused-expressions: off */
 
-const expect = require('chai').expect
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+
+chai.use(chaiAsPromised)
+
+const expect = chai.expect
+
 const mocha = require('mocha')
 const describe = mocha.describe
 const it = mocha.it
@@ -47,5 +53,15 @@ describe('kafka:credentials', () => {
 
     return cmd.run({app: 'myapp', args: {CLUSTER: undefined}, flags: { reset: true }})
       .then(() => expect(cli.stderr).to.be.empty)
+  })
+
+  it(`requires the --reset flag`, () => {
+    return expect(cmd.run({app: 'myapp', args: {CLUSTER: undefined}, flags: {}}))
+      .to.be.rejected
+      .then((err) => {
+        expect(cli.stdout).to.be.empty
+        expect(cli.stderr).to.be.empty
+        expect(err.message).to.equal('The --reset flag is required for this command')
+      })
   })
 })


### PR DESCRIPTION
The CLI framework has some quirks around boolean flags, including that
they don't obey the required option (which admittedly is kind of a
weird thing to do; this was originally done for consistency with
Postgres but now Postgres does something different). Work around this
by explicitly checking for the presence of the flag.