### PR TITLE
use cli.color instead of using chalk directly

### DIFF
--- a/lib/utilizationBar.js
+++ b/lib/utilizationBar.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const chalk = require('chalk')
+const cli = require('heroku-cli-util')
 
 module.exports = function (current, total, width = 10) {
   let percentage = current / total
@@ -8,7 +8,7 @@ module.exports = function (current, total, width = 10) {
   if (percentage < 0) percentage = 0
   const filled = Math.floor(percentage * width)
   const empty = width - filled
-  let output = chalk.blue('█'.repeat(filled))
+  let output = cli.color.blue('█'.repeat(filled))
   output += '·'.repeat(empty)
   return `[${output}]`
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "url": "https://github.com/heroku/heroku-kafka-jsplugin/issues"
   },
   "dependencies": {
-    "chalk": "^2.0.1",
     "co": "4.6.0",
     "co-wait": "0.0.0",
     "debug": "2.6.8",

--- a/test/lib/utilizationBar_test.js
+++ b/test/lib/utilizationBar_test.js
@@ -3,11 +3,19 @@
 const expect = require('chai').expect
 const mocha = require('mocha')
 const describe = mocha.describe
+const beforeEach = mocha.beforeEach
 const it = mocha.it
+
+const cli = require('heroku-cli-util')
 
 const utilizationBar = require('../../lib/utilizationBar')
 
 describe('utilizationBar', function () {
+  beforeEach(() => {
+    cli.mockConsole()
+    cli.color.enabled = true
+  })
+
   const cases = [
     [0, 100, '[··········]', '[···············]'],
     [100, 100, '[\u001b[34m██████████\u001b[39m]', '[\u001b[34m███████████████\u001b[39m]'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,12 +61,6 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.1.0.tgz#09c202d5c917ec23188caa5c9cb9179cd9547750"
-  dependencies:
-    color-convert "^1.0.0"
-
 ansicolors@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.2.1.tgz#be089599097b74a5c9c4a84a0cdbcdb62bd87aef"
@@ -406,14 +400,6 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
-  dependencies:
-    ansi-styles "^3.1.0"
-    escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
-
 circular-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
@@ -476,16 +462,6 @@ co@4.6.0, co@^4.6.0:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
-
-color-convert@^1.0.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
-  dependencies:
-    color-name "^1.1.1"
-
-color-name@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.2.tgz#5c8ab72b64bd2215d617ae9559ebb148475cf98d"
 
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
@@ -1253,10 +1229,6 @@ has-color@^0.1.7:
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
-
-has-flag@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -2980,12 +2952,6 @@ supports-color@^3.1.2:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
-
-supports-color@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.2.0.tgz#ad986dc7eb2315d009b4d77c8169c2231a684037"
-  dependencies:
-    has-flag "^2.0.0"
 
 symbol-observable@^1.0.1:
   version "1.0.4"


### PR DESCRIPTION
This lets us mock out color handling consistently in tests (cf. the current issue with `yarn release`).