### PR TITLE
Make the kafka topic prefix more explicit

### DIFF
--- a/commands/topics.js
+++ b/commands/topics.js
@@ -19,6 +19,9 @@ function * listTopics (context, heroku) {
     if (topics.topics.length !== 0 && topics.limits && topics.limits.max_topics) {
       cli.log(`${topics.topics.length} / ${topics.limits.max_topics} topics`)
     }
+    if (topics.prefix) {
+      cli.log(`prefix: ${topics.prefix}`)
+    }
 
     let filtered = topics.topics.filter((t) => t.name !== '__consumer_offsets')
     let topicData = filtered.map((t) => {
@@ -57,6 +60,9 @@ let cmd = {
   description: 'lists available Kafka topics',
   help: `
     Lists available Kafka topics.
+
+    Note that some plans use a topic prefix; to learn more,
+    visit https://devcenter.heroku.com/articles/multi-tenant-kafka-on-heroku#connecting-kafka-prefix
 
     Examples:
 

--- a/commands/topics.js
+++ b/commands/topics.js
@@ -16,11 +16,17 @@ function * listTopics (context, heroku) {
     })
     cli.styledHeader('Kafka Topics on ' + (topics.attachment_name || 'HEROKU_KAFKA'))
 
-    if (topics.topics.length !== 0 && topics.limits && topics.limits.max_topics) {
-      cli.log(`${topics.topics.length} / ${topics.limits.max_topics} topics`)
-    }
-    if (topics.prefix) {
-      cli.log(`prefix: ${topics.prefix}`)
+    if (topics.topics.length !== 0) {
+      const extraInfo = []
+      if (topics.limits && topics.limits.max_topics) {
+        extraInfo.push(`${topics.topics.length} / ${topics.limits.max_topics} topics`)
+      }
+      if (topics.prefix) {
+        extraInfo.push(`prefix: ${cli.color.green(topics.prefix)}`)
+      }
+      if (extraInfo.length > 0) {
+        cli.log(extraInfo.join('; '))
+      }
     }
 
     let filtered = topics.topics.filter((t) => t.name !== '__consumer_offsets')

--- a/commands/topics_create.js
+++ b/commands/topics_create.js
@@ -53,7 +53,7 @@ function * createTopic (context, heroku) {
 
     cli.log(`Use \`heroku kafka:topics:info ${context.args.TOPIC}\` to monitor your topic.`)
     if (addonInfo.topic_prefix) {
-      cli.log(`Your topic is using the prefix '${addonInfo.topic_prefix}'. Learn more in Dev Center:`)
+      cli.log(`Your topic is using the prefix ${cli.color.green(addonInfo.topic_prefix)}. Learn more in Dev Center:`)
       cli.log('  https://devcenter.heroku.com/articles/multi-tenant-kafka-on-heroku#connecting-kafka-prefix')
     }
   })

--- a/commands/topics_create.js
+++ b/commands/topics_create.js
@@ -52,6 +52,10 @@ function * createTopic (context, heroku) {
     }))
 
     cli.log(`Use \`heroku kafka:topics:info ${context.args.TOPIC}\` to monitor your topic.`)
+    if (addonInfo.topic_prefix) {
+      cli.log(`Your topic is using the prefix '${addonInfo.topic_prefix}'. Learn more in Dev Center:`)
+      cli.log('  https://devcenter.heroku.com/articles/multi-tenant-kafka-on-heroku#connecting-kafka-prefix')
+    }
   })
 }
 

--- a/commands/topics_info.js
+++ b/commands/topics_info.js
@@ -41,6 +41,13 @@ function topicInfo (topic) {
     }
   ]
 
+  if (topic.prefix) {
+    lines.unshift({
+      name: 'Topic Prefix',
+      values: [ topic.prefix ]
+    })
+  }
+
   if (topic.compaction) {
     lines.push({
       name: 'Compaction',
@@ -85,7 +92,10 @@ let cmd = {
     { name: 'CLUSTER', optional: true }
   ],
   help: `
-    Shows information about a topic in your Kafka cluster
+    Shows information about a topic in your Kafka cluster.
+
+    Note that some plans use a topic prefix; to learn more,
+    visit https://devcenter.heroku.com/articles/multi-tenant-kafka-on-heroku#connecting-kafka-prefix
 
     Examples:
 

--- a/commands/topics_info.js
+++ b/commands/topics_info.js
@@ -44,7 +44,7 @@ function topicInfo (topic) {
   if (topic.prefix) {
     lines.unshift({
       name: 'Topic Prefix',
-      values: [ topic.prefix ]
+      values: [ cli.color.green(topic.prefix) ]
     })
   }
 

--- a/test/commands/topics_create_test.js
+++ b/test/commands/topics_create_test.js
@@ -80,6 +80,33 @@ describe('kafka:topics:create', () => {
       })
   })
 
+  it('includes the topic prefix and link in output if one exists', () => {
+    const prefix = 'mill-4567.'
+    kafka.get(infoUrl('00000000-0000-0000-0000-000000000000'))
+      .reply(200, { topic_prefix: prefix })
+    kafka.post(createUrl('00000000-0000-0000-0000-000000000000'),
+      {
+        topic: {
+          name: 'topic-1',
+          retention_time_ms: 10,
+          replication_factor: '3',
+          partition_count: '7',
+          compaction: false
+        }
+      }).reply(200)
+
+    return cmd.run({app: 'myapp',
+      args: { TOPIC: 'topic-1' },
+      flags: { 'replication-factor': '3',
+        'retention-time': '10ms',
+        'partitions': '7' }}
+    )
+      .then(() => {
+        expect(cli.stderr).to.equal('Creating topic topic-1 with compaction disabled and retention time 10 milliseconds on kafka-1... done\n')
+        expect(cli.stdout).to.equal(`Use \`heroku kafka:topics:info topic-1\` to monitor your topic.\nYour topic is using the prefix '${prefix}'. Learn more in Dev Center:\n  https://devcenter.heroku.com/articles/multi-tenant-kafka-on-heroku#connecting-kafka-prefix\n`)
+      })
+  })
+
   it('defaults retention to the plan minimum if not specified even if retention specified', () => {
     kafka.get(infoUrl('00000000-0000-0000-0000-000000000000'))
       .reply(200, { shared_cluster: false, limits: { minimum_retention_ms: 66 } })

--- a/test/commands/topics_create_test.js
+++ b/test/commands/topics_create_test.js
@@ -103,7 +103,7 @@ describe('kafka:topics:create', () => {
     )
       .then(() => {
         expect(cli.stderr).to.equal('Creating topic topic-1 with compaction disabled and retention time 10 milliseconds on kafka-1... done\n')
-        expect(cli.stdout).to.equal(`Use \`heroku kafka:topics:info topic-1\` to monitor your topic.\nYour topic is using the prefix '${prefix}'. Learn more in Dev Center:\n  https://devcenter.heroku.com/articles/multi-tenant-kafka-on-heroku#connecting-kafka-prefix\n`)
+        expect(cli.stdout).to.equal(`Use \`heroku kafka:topics:info topic-1\` to monitor your topic.\nYour topic is using the prefix ${prefix}. Learn more in Dev Center:\n  https://devcenter.heroku.com/articles/multi-tenant-kafka-on-heroku#connecting-kafka-prefix\n`)
       })
   })
 

--- a/test/commands/topics_info_test.js
+++ b/test/commands/topics_info_test.js
@@ -71,6 +71,38 @@ Retention:          24 hours
       .then(() => expect(cli.stderr).to.be.empty)
   })
 
+  it('displays a topic prefix if one is specified', () => {
+    kafka.get(topicsUrl('00000000-0000-0000-0000-000000000000')).reply(200, {
+      attachment_name: 'HEROKU_KAFKA_BLUE_URL',
+      topics: [
+        {
+          name: 'topic-1',
+          prefix: 'wisła-12345.',
+          messages_in_per_second: 0,
+          bytes_in_per_second: 0,
+          bytes_out_per_second: 0,
+          replication_factor: 3,
+          partitions: 3,
+          compaction: false,
+          retention_time_ms: 86400000
+        }
+      ]
+    })
+
+    return cmd.run({app: 'myapp', args: { TOPIC: 'topic-1' }})
+      .then(() => expect(cli.stdout).to.equal(`=== kafka-1 :: topic-1
+
+Topic Prefix:       wisła-12345.
+Producers:          0 messages/second (0 bytes/second) total
+Consumers:          0 bytes/second total
+Partitions:         3 partitions
+Replication Factor: 3
+Compaction:         Compaction is disabled for topic-1
+Retention:          24 hours
+`))
+      .then(() => expect(cli.stderr).to.be.empty)
+  })
+
   it('tells user the topic is not ready', () => {
     kafka.get(topicsUrl('00000000-0000-0000-0000-000000000000')).reply(200, {
       attachment_name: 'HEROKU_KAFKA_BLUE_URL',

--- a/test/commands/topics_test.js
+++ b/test/commands/topics_test.js
@@ -102,6 +102,32 @@ topic-2  12/sec    3 bytes/sec
         .then(() => expect(cli.stderr).to.be.empty)
     })
 
+    it('includes prefix information if one exists', () => {
+      const prefix = 'russian-12345.'
+      kafka.get(topicsUrl('00000000-0000-0000-0000-000000000000')).reply(200, {
+        attachment_name: 'HEROKU_KAFKA_BLUE_URL',
+        prefix,
+        topics: [
+          { name: 'topic-1', messages_in_per_second: 10.0, bytes_in_per_second: 0 },
+          { name: 'topic-2', messages_in_per_second: 12.0, bytes_in_per_second: 3 }
+        ],
+        limits: {
+          max_topics: 10
+        }
+      })
+
+      return cmd.run({app: 'myapp', args: {}})
+        .then(() => expect(cli.stdout).to.equal(`=== Kafka Topics on HEROKU_KAFKA_BLUE_URL
+2 / 10 topics; prefix: ${prefix}
+
+Name     Messages  Traffic
+───────  ────────  ───────────
+topic-1  10/sec    0 bytes/sec
+topic-2  12/sec    3 bytes/sec
+`))
+        .then(() => expect(cli.stderr).to.be.empty)
+    })
+
     it('omits information about the special __consumer_offsets topic', () => {
       kafka.get(topicsUrl('00000000-0000-0000-0000-000000000000')).reply(200, {
         attachment_name: 'HEROKU_KAFKA_BLUE_URL',


### PR DESCRIPTION
So I coded up what we talked about in https://github.com/heroku/herokudata/issues/870 , but the Dev Center links don't feel right: they take up a disproportionate amount of room. I think we should keep it in topic creation, but drop it in other places and just list the prefix there. Thoughts?

topic creation:
```
maciek@mothra:~/code/heroku-kafka-jsplugin$ h kafka:topics:create foobar -a multitenant-kafka
Creating topic foobar with compaction disabled and retention time 1 day on kafka-encircled-64755... done
Use `heroku kafka:topics:info foobar` to monitor your topic.
Your topic is using the prefix 'colville-77398.'. Learn more in Dev Center:
  https://devcenter.heroku.com/articles/multi-tenant-kafka-on-heroku#connecting-kafka-prefix
```

topic listing:
```
maciek@mothra:~/code/heroku-kafka-jsplugin$ h kafka:topics -a multitenant-kafka
=== Kafka Topics on KAFKA_URL
6 / 10 topics
prefix: colville-77398. (see https://devcenter.heroku.com/articles/multi-tenant-kafka-on-heroku#connecting-kafka-prefix )

Name    Messages  Traffic
──────  ────────  ───────────
foobar  0/sec     0 bytes/sec
lala2   0/sec     0 bytes/sec
lala3   0/sec     0 bytes/sec
lala4   0/sec     0 bytes/sec
lala5   0/sec     0 bytes/sec
lala6   0/sec     0 bytes/sec
```

topic info:
```
maciek@mothra:~/code/heroku-kafka-jsplugin$ h kafka:topics:info foobar -a multitenant-kafka
=== kafka-encircled-64755 :: foobar

Topic Prefix:       colville-77398. (see https://devcenter.heroku.com/articles/multi-tenant-kafka-on-heroku#connecting-kafka-prefix )
Producers:          0 messages/second (0 bytes/second) total
Consumers:          0 bytes/second total
Partitions:         8 partitions
Replication Factor: 3
Compaction:         Compaction is disabled for foobar
Retention:          24 hours
```