### PR TITLE
fix casing of cluster constant

### DIFF
--- a/commands/wait.js
+++ b/commands/wait.js
@@ -8,7 +8,7 @@ const HerokuKafkaClusters = require('../lib/clusters').HerokuKafkaClusters
 function * run (context, heroku) {
   const fetcher = require('../lib/fetcher')(heroku)
   const app = context.app
-  const cluster = context.args.cluster
+  const cluster = context.args.CLUSTER
 
   const shogun = new HerokuKafkaClusters(heroku, process.env, context)
 

--- a/test/commands/wait_test.js
+++ b/test/commands/wait_test.js
@@ -50,7 +50,7 @@ describe('kafka:wait', () => {
       .get(waitUrl('00000000-0000-0000-0000-000000000000')).reply(200, {'waiting?': true, message: 'pending'})
       .get(waitUrl('00000000-0000-0000-0000-000000000000')).reply(200, {'waiting?': false, message: 'available'})
 
-    return cmd.run({app: 'myapp', args: {cluster: 'KAFKA_URL'}, flags: {'wait-interval': '1'}})
+    return cmd.run({app: 'myapp', args: {CLUSTER: 'KAFKA_URL'}, flags: {'wait-interval': '1'}})
       .then(() => expect(cli.stdout).to.be.empty)
       .then(() => expect(cli.stderr).to.equal(`Waiting for cluster kafka-1... pending
 Waiting for cluster kafka-1... available


### PR DESCRIPTION
Running `heroku kafka:wait COLOR -a sushi` on my app will not honor the attachment name and instead return data on **all** addons. This PR fixes the `cluster` constant so that it does honor that attachment name if provided.