### PR TITLE
Drop obsolete coveralls.yaml

### DIFF
--- a/.coveralls.yaml
+++ b/.coveralls.yaml
@@ -1,2 +1,0 @@
-service_name: travis-pro
-repo_token: l27DbceI9056fF2ZOIQwSkjUWuROtHbSo


### PR DESCRIPTION
This appears to no longer be necessary