### PR TITLE
fix: interval formatting helper in node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "8.1.3"
+  - "10.18.0"
+  - "12.14.0"
 env:
   - CXX=g++-4.9
 addons:

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -112,7 +112,8 @@ function formatIntervalFromMilliseconds (milliseconds) {
     minute: (60 * 1000),
     second: 1000
   }
-  let intervals = Object.keys(multipliers).sort((interval) => -multipliers[interval])
+  let intervals = Object.keys(multipliers)
+    .sort((intervalA, intervalB) => multipliers[intervalB] - multipliers[intervalA])
   let values = intervals.reduce((accum, interval) => { accum[interval] = 0; return accum }, {})
   let smallest = multipliers[intervals[intervals.length - 1]]
 


### PR DESCRIPTION
* fix `formatIntervalFromMilliseconds` in node 12.
* bump test matrix from node 8 to node 10 and node 12.