### PR TITLE
feat: remove Private restriction on write/tail

### DIFF
--- a/commands/topics_tail.js
+++ b/commands/topics_tail.js
@@ -35,7 +35,7 @@ function * tail (context, heroku) {
       yield consumer.init()
     } catch (e) {
       debug(e)
-      throw new Error('Could not connect to kafka')
+      cli.exit(1, 'Could not connect to kafka')
     }
 
     var topicName = context.args.TOPIC

--- a/commands/topics_tail.js
+++ b/commands/topics_tail.js
@@ -62,7 +62,7 @@ function * tail (context, heroku) {
         })
       } catch (e) {
         debug(e)
-        reject(new Error('Could not subscribe to topic'))
+        cli.exit(1, 'Could not subscribe to topic')
       }
     })
   })

--- a/commands/topics_tail.js
+++ b/commands/topics_tail.js
@@ -5,7 +5,6 @@ const co = require('co')
 
 const debug = require('../lib/debug')
 const clusterConfig = require('../lib/shared').clusterConfig
-const isPrivate = require('../lib/shared').isPrivate
 const deprecated = require('../lib/shared').deprecated
 const withCluster = require('../lib/clusters').withCluster
 
@@ -16,10 +15,6 @@ const MAX_LENGTH = 80
 function * tail (context, heroku) {
   const kafka = require('@heroku/no-kafka')
   yield withCluster(heroku, context.app, context.args.CLUSTER, function * (addon) {
-    if (isPrivate(addon)) {
-      throw new Error('`kafka:topics:tail` is not available in Heroku Private Spaces')
-    }
-
     let appConfig = yield heroku.get(`/apps/${context.app}/config-vars`)
     let attachment = yield heroku.get(`/apps/${context.app}/addon-attachments/${addon.name}`,
       { headers: { 'accept-inclusion': 'config_vars' } })

--- a/commands/topics_write.js
+++ b/commands/topics_write.js
@@ -5,7 +5,6 @@ const co = require('co')
 
 const debug = require('../lib/debug')
 const clusterConfig = require('../lib/shared').clusterConfig
-const isPrivate = require('../lib/shared').isPrivate
 const deprecated = require('../lib/shared').deprecated
 const withCluster = require('../lib/clusters').withCluster
 
@@ -15,10 +14,6 @@ const IDLE_TIMEOUT = 1000
 function * write (context, heroku) {
   const kafka = require('@heroku/no-kafka')
   yield withCluster(heroku, context.app, context.args.CLUSTER, function * (addon) {
-    if (isPrivate(addon)) {
-      cli.exit(1, '`kafka:topics:write` is not available in Heroku Private Spaces')
-    }
-
     let appConfig = yield heroku.get(`/apps/${context.app}/config-vars`)
     let attachment = yield heroku.get(`/apps/${context.app}/addon-attachments/${addon.name}`,
       { headers: { 'accept-inclusion': 'config_vars' } })

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -41,7 +41,7 @@ function clusterConfig (attachment, config) {
 }
 
 function isPrivate (addon) {
-  return addon.plan.name.indexOf('private-') !== -1
+  return addon.plan.name.indexOf('private-') !== -1 || addon.plan.name.indexOf('shield-') !== -1
 }
 
 function parseBool (boolStr) {

--- a/test/commands/topics_tail_test.js
+++ b/test/commands/topics_tail_test.js
@@ -74,17 +74,6 @@ describe('kafka:topics:tail', () => {
     tail.process = global.process
   })
 
-  it('warns and exits with an error if used with a Private Spaces cluster', () => {
-    planName = 'heroku-kafka:beta-private-standard-2'
-    return cmd.run({app: 'myapp', args: { TOPIC: 'topic-1' }})
-      .then(() => { throw new Error('expected error; got none') })
-      .catch((err) => {
-        expect(err.message).to.equal('`kafka:topics:tail` is not available in Heroku Private Spaces')
-        expect(cli.stdout).to.be.empty
-        expect(cli.stderr).to.be.empty
-      })
-  })
-
   it('warns and exits with an error if it cannot connect', () => {
     api.get('/apps/myapp/config-vars').reply(200, config)
     api.get('/apps/myapp/addon-attachments/kafka-1')

--- a/test/commands/topics_tail_test.js
+++ b/test/commands/topics_tail_test.js
@@ -8,6 +8,7 @@ const it = mocha.it
 const beforeEach = mocha.beforeEach
 const afterEach = mocha.afterEach
 const proxyquire = require('proxyquire')
+const expectExit = require('../expect_exit')
 
 const cli = require('heroku-cli-util')
 const nock = require('nock')

--- a/test/commands/topics_tail_test.js
+++ b/test/commands/topics_tail_test.js
@@ -80,13 +80,9 @@ describe('kafka:topics:tail', () => {
       .reply(200, { name: 'KAFKA', config_vars: stockConfigVars, app: { name: 'sushi' } })
     consumer.init = () => { throw new Error('oh snap') }
 
-    return cmd.run({app: 'myapp', args: { TOPIC: 'topic-1' }})
-      .then(() => { throw new Error('expected error; got none') })
-      .catch((err) => {
-        expect(err.message).to.equal(`Could not connect to kafka`)
-        expect(cli.stdout).to.be.empty
-        expect(cli.stderr).to.be.empty
-      })
+    return expectExit(1, cmd.run({app: 'myapp', args: { TOPIC: 'topic-1' }}))
+      .then(() => expect(cli.stdout).to.be.empty)
+      .then(() => expect(cli.stderr).to.equal(` ▸    Could not connect to kafka\n`))
   })
 
   it('warns and exits with an error if it cannot subscribe', () => {
@@ -95,13 +91,9 @@ describe('kafka:topics:tail', () => {
       .reply(200, { name: 'KAFKA', config_vars: stockConfigVars, app: { name: 'sushi' } })
     consumer.subscribe = () => { throw new Error('oh snap') }
 
-    return cmd.run({app: 'myapp', args: { TOPIC: 'topic-1' }})
-      .then(() => { throw new Error('expected error; got none') })
-      .catch((err) => {
-        expect(err.message).to.equal('Could not subscribe to topic')
-        expect(cli.stdout).to.be.empty
-        expect(cli.stderr).to.be.empty
-      })
+    return expectExit(1, cmd.run({app: 'myapp', args: { TOPIC: 'topic-1' }, flags: {}}))
+      .then(() => expect(cli.stdout).to.be.empty)
+      .then(() => expect(cli.stderr).to.equal(` ▸    Could not subscribe to topic\n`))
   })
 
   it('tails a topic and prints the results', () => {

--- a/test/commands/topics_write_test.js
+++ b/test/commands/topics_write_test.js
@@ -76,13 +76,6 @@ describe('kafka:topics:write', () => {
     api.done()
   })
 
-  it('warns and exits with an error if used with a Private Spaces cluster', () => {
-    planName = 'heroku-kafka:beta-private-standard-2'
-    return expectExit(1, cmd.run({app: 'myapp', args: { TOPIC: 'topic-1' }}))
-      .then(() => expect(cli.stdout).to.be.empty)
-      .then(() => expect(cli.stderr).to.equal(' ▸    `kafka:topics:write` is not available in Heroku Private Spaces\n'))
-  })
-
   it('warns and exits with an error if it cannot connect', () => {
     api.get('/apps/myapp/config-vars').reply(200, config)
     api.get('/apps/myapp/addon-attachments/kafka-1')

--- a/test/lib/shared_test.js
+++ b/test/lib/shared_test.js
@@ -64,7 +64,7 @@ describe('isPrivate', function () {
     [ { plan: { name: 'private-standard-2' } }, true ],
     [ { plan: { name: 'private-extended-0' } }, true ],
     [ { plan: { name: 'private-extended-1' } }, true ],
-    [ { plan: { name: 'private-extended-2' } }, true ]
+    [ { plan: { name: 'private-extended-2' } }, true ],
     [ { plan: { name: 'shield-standard-0' } }, true ],
     [ { plan: { name: 'shield-standard-1' } }, true ],
     [ { plan: { name: 'shield-standard-2' } }, true ],

--- a/test/lib/shared_test.js
+++ b/test/lib/shared_test.js
@@ -53,18 +53,24 @@ describe('parseDuration', function () {
 
 describe('isPrivate', function () {
   let cases = [
-    [ { plan: { name: 'beta-standard-0' } }, false ],
-    [ { plan: { name: 'beta-standard-1' } }, false ],
-    [ { plan: { name: 'beta-standard-2' } }, false ],
-    [ { plan: { name: 'beta-extended-0' } }, false ],
-    [ { plan: { name: 'beta-extended-1' } }, false ],
-    [ { plan: { name: 'beta-extended-2' } }, false ],
-    [ { plan: { name: 'beta-private-standard-0' } }, true ],
-    [ { plan: { name: 'beta-private-standard-1' } }, true ],
-    [ { plan: { name: 'beta-private-standard-2' } }, true ],
-    [ { plan: { name: 'beta-private-extended-0' } }, true ],
-    [ { plan: { name: 'beta-private-extended-1' } }, true ],
-    [ { plan: { name: 'beta-private-extended-2' } }, true ]
+    [ { plan: { name: 'standard-0' } }, false ],
+    [ { plan: { name: 'standard-1' } }, false ],
+    [ { plan: { name: 'standard-2' } }, false ],
+    [ { plan: { name: 'extended-0' } }, false ],
+    [ { plan: { name: 'extended-1' } }, false ],
+    [ { plan: { name: 'extended-2' } }, false ],
+    [ { plan: { name: 'private-standard-0' } }, true ],
+    [ { plan: { name: 'private-standard-1' } }, true ],
+    [ { plan: { name: 'private-standard-2' } }, true ],
+    [ { plan: { name: 'private-extended-0' } }, true ],
+    [ { plan: { name: 'private-extended-1' } }, true ],
+    [ { plan: { name: 'private-extended-2' } }, true ]
+    [ { plan: { name: 'shield-standard-0' } }, true ],
+    [ { plan: { name: 'shield-standard-1' } }, true ],
+    [ { plan: { name: 'shield-standard-2' } }, true ],
+    [ { plan: { name: 'shield-extended-0' } }, true ],
+    [ { plan: { name: 'shield-extended-1' } }, true ],
+    [ { plan: { name: 'shield-extended-2' } }, true ]
   ]
   cases.forEach(function (testcase) {
     let addon = testcase[0]


### PR DESCRIPTION
New Private & Shield Kafka addons can use `kafka:topics:write` and `kafka:topics:tail`. This PR removes that guard.