### PR TITLE
fix: Update help for write/tail ingress requirements

### DIFF
--- a/commands/topics_tail.js
+++ b/commands/topics_tail.js
@@ -71,7 +71,7 @@ function * tail (context, heroku) {
 let cmd = {
   topic: 'kafka',
   command: 'topics:tail',
-  description: '(only outside Private Spaces) tails a topic in Kafka',
+  description: 'tails a topic in Kafka',
   args: [
     { name: 'TOPIC' },
     { name: 'CLUSTER', optional: true }
@@ -80,7 +80,9 @@ let cmd = {
     { name: 'max-length', description: 'number of characters per message to output', hasValue: true }
   ],
   help: `
-    Tails a topic in Kafka. Note: kafka:tail is not available in Heroku Private Spaces.
+    Tails a topic in Kafka.
+    Note: kafka:topics:tail for Private/Shield Spaces requires ingress configuration:
+    https://devcenter.heroku.com/articles/kafka-on-heroku#connecting-to-a-private-or-shield-kafka-cluster-from-an-external-resource
 
     Examples:
 

--- a/commands/topics_write.js
+++ b/commands/topics_write.js
@@ -71,7 +71,7 @@ function * write (context, heroku) {
 let cmd = {
   topic: 'kafka',
   command: 'topics:write',
-  description: '(only outside Private Spaces) writes a message to a Kafka topic',
+  description: 'writes a message to a Kafka topic',
   args: [
     { name: 'TOPIC' },
     { name: 'MESSAGE' },
@@ -82,7 +82,9 @@ let cmd = {
     { name: 'partition', description: 'the partition to write to', hasValue: true }
   ],
   help: `
-    Writes a message to the specified Kafka topic. Note: kafka:tail is not available in Heroku Private Spaces.
+    Writes a message to the specified Kafka topic.
+    Note: kafka:topics:write for Private/Shield Spaces requires ingress configuration:
+    https://devcenter.heroku.com/articles/kafka-on-heroku#connecting-to-a-private-or-shield-kafka-cluster-from-an-external-resource
 
     Examples:
 


### PR DESCRIPTION
`kafka:topics:tail` and `kafka:topics:write` work just fine for
Private/Shield spaces if and only if ingress rules are set up
appopriately for mTLS.