### PR TITLE
Clarify Private and Shield access in topics:tail and topics:write commands

### DIFF
--- a/commands/topics_tail.js
+++ b/commands/topics_tail.js
@@ -71,7 +71,7 @@ function * tail (context, heroku) {
 let cmd = {
   topic: 'kafka',
   command: 'topics:tail',
-  description: '(only outside Private Spaces) tails a topic in Kafka',
+  description: 'tails a topic in Kafka',
   args: [
     { name: 'TOPIC' },
     { name: 'CLUSTER', optional: true }
@@ -80,7 +80,8 @@ let cmd = {
     { name: 'max-length', description: 'number of characters per message to output', hasValue: true }
   ],
   help: `
-    Tails a topic in Kafka. Note: kafka:tail is not available in Heroku Private Spaces.
+    Consumes messages from a topic in Kafka.  Note: For Private and Shield plans,
+    configure mutual TLS first to allow external connections to your cluster.
 
     Examples:
 

--- a/commands/topics_write.js
+++ b/commands/topics_write.js
@@ -71,7 +71,7 @@ function * write (context, heroku) {
 let cmd = {
   topic: 'kafka',
   command: 'topics:write',
-  description: '(only outside Private Spaces) writes a message to a Kafka topic',
+  description: 'writes a message to a Kafka topic',
   args: [
     { name: 'TOPIC' },
     { name: 'MESSAGE' },
@@ -82,7 +82,8 @@ let cmd = {
     { name: 'partition', description: 'the partition to write to', hasValue: true }
   ],
   help: `
-    Writes a message to the specified Kafka topic. Note: kafka:tail is not available in Heroku Private Spaces.
+    Writes a message to the specified Kafka topic. Note: For Private and Shield plans,
+    configure mutual TLS first to allow external connections to your cluster.
 
     Examples:
 


### PR DESCRIPTION
Using these commands in Private and Shield clusters is possible if customers allowlist the IP addresses they're connecting from with the mTLS feature.

Updating the help messages of these commands to clarify that.

