### PR TITLE
Updates default host to api.data.heroku.com

### DIFF
--- a/lib/host.js
+++ b/lib/host.js
@@ -1,15 +1,5 @@
 'use strict'
 
-let DEFAULT_HOST = 'kafka-api.heroku.com'
-
 module.exports = function () {
-  if (process.env.HEROKU_KAFKA_HOST) {
-    return process.env.HEROKU_KAFKA_HOST
-  } else if (process.env.SHOGUN) {
-    return `shogun-${process.env.SHOGUN}.herokuapp.com`
-  } else if (process.env.DEPLOY) {
-    return `shogun-${process.env.DEPLOY}.herokuapp.com`
-  } else {
-    return DEFAULT_HOST
-  }
+  return process.env.HEROKU_KAFKA_HOST || 'api.data.heroku.com'
 }

--- a/test/commands/consumer_groups_create_test.js
+++ b/test/commands/consumer_groups_create_test.js
@@ -32,7 +32,7 @@ describe('kafka:consumer-groups:create', () => {
   }
 
   beforeEach(() => {
-    kafka = nock('https://kafka-api.heroku.com:443')
+    kafka = nock('https://api.data.heroku.com:443')
     cli.mockConsole()
     cli.exit.mock()
   })

--- a/test/commands/consumer_groups_destroy_test.js
+++ b/test/commands/consumer_groups_destroy_test.js
@@ -44,7 +44,7 @@ describe('kafka:consumer-groups:destroy', () => {
 
   beforeEach(() => {
     confirm = cli.confirmApp
-    kafka = nock('https://kafka-api.heroku.com:443')
+    kafka = nock('https://api.data.heroku.com:443')
 
     cli.exit.mock()
     cli.confirmApp = confirmApp

--- a/test/commands/consumer_groups_test.js
+++ b/test/commands/consumer_groups_test.js
@@ -32,7 +32,7 @@ describe('kafka:consumer-groups', () => {
   }
 
   beforeEach(() => {
-    kafka = nock('https://kafka-api.heroku.com:443')
+    kafka = nock('https://api.data.heroku.com:443')
     cli.mockConsole()
     cli.exit.mock()
   })

--- a/test/commands/credentials_rotate_test.js
+++ b/test/commands/credentials_rotate_test.js
@@ -38,7 +38,7 @@ describe('kafka:credentials', () => {
 
   beforeEach(() => {
     planName = 'heroku-kafka:beta-private-standard-2'
-    kafka = nock('https://kafka-api.heroku.com:443')
+    kafka = nock('https://api.data.heroku.com:443')
     cli.mockConsole()
     cli.exit.mock()
   })

--- a/test/commands/fail_test.js
+++ b/test/commands/fail_test.js
@@ -42,7 +42,7 @@ describe('kafka:fail', () => {
 
   beforeEach(() => {
     confirm = cli.confirmApp
-    kafka = nock('https://kafka-api.heroku.com:443')
+    kafka = nock('https://api.data.heroku.com:443')
 
     cli.confirmApp = confirmApp
     cli.mockConsole()

--- a/test/commands/host_test.js
+++ b/test/commands/host_test.js
@@ -10,6 +10,6 @@ const host = require('../../lib/host.js')
 
 describe('host', () => {
   it(`is the default host`, () => {
-    expect(host()).to.equal('kafka-api.heroku.com')
+    expect(host()).to.equal('api.data.heroku.com')
   })
 })

--- a/test/commands/info_test.js
+++ b/test/commands/info_test.js
@@ -38,7 +38,7 @@ describe('kafka:info', () => {
 
   beforeEach(() => {
     api = nock('https://api.heroku.com:443')
-    kafka = nock('https://kafka-api.heroku.com:443')
+    kafka = nock('https://api.data.heroku.com:443')
     cli.mockConsole()
   })
 

--- a/test/commands/topics_compaction_test.js
+++ b/test/commands/topics_compaction_test.js
@@ -39,7 +39,7 @@ describe('kafka:topics:compaction', () => {
   }
 
   beforeEach(() => {
-    kafka = nock('https://kafka-api.heroku.com:443')
+    kafka = nock('https://api.data.heroku.com:443')
     cli.mockConsole()
     cli.exit.mock()
   })

--- a/test/commands/topics_create_test.js
+++ b/test/commands/topics_create_test.js
@@ -35,7 +35,7 @@ describe('kafka:topics:create', () => {
   }
 
   beforeEach(() => {
-    kafka = nock('https://kafka-api.heroku.com:443')
+    kafka = nock('https://api.data.heroku.com:443')
 
     cli.exit.mock()
     cli.mockConsole()

--- a/test/commands/topics_destroy_test.js
+++ b/test/commands/topics_destroy_test.js
@@ -42,7 +42,7 @@ describe('kafka:topics:destroy', () => {
 
   beforeEach(() => {
     confirm = cli.confirmApp
-    kafka = nock('https://kafka-api.heroku.com:443')
+    kafka = nock('https://api.data.heroku.com:443')
 
     cli.exit.mock()
     cli.confirmApp = confirmApp

--- a/test/commands/topics_info_test.js
+++ b/test/commands/topics_info_test.js
@@ -31,7 +31,7 @@ describe('kafka:topics:info', () => {
   }
 
   beforeEach(() => {
-    kafka = nock('https://kafka-api.heroku.com:443')
+    kafka = nock('https://api.data.heroku.com:443')
     cli.mockConsole()
     cli.exit.mock()
   })

--- a/test/commands/topics_replication_factor_test.js
+++ b/test/commands/topics_replication_factor_test.js
@@ -34,7 +34,7 @@ describe('kafka:topics:replication-factor', () => {
   }
 
   beforeEach(() => {
-    kafka = nock('https://kafka-api.heroku.com:443')
+    kafka = nock('https://api.data.heroku.com:443')
     cli.mockConsole()
     cli.exit.mock()
   })

--- a/test/commands/topics_retention_time_test.js
+++ b/test/commands/topics_retention_time_test.js
@@ -39,7 +39,7 @@ describe('kafka:topics:retention-time', () => {
   }
 
   beforeEach(() => {
-    kafka = nock('https://kafka-api.heroku.com:443')
+    kafka = nock('https://api.data.heroku.com:443')
     cli.mockConsole()
     cli.exit.mock()
   })

--- a/test/commands/topics_test.js
+++ b/test/commands/topics_test.js
@@ -30,7 +30,7 @@ describe('kafka:topics', () => {
   }
 
   beforeEach(() => {
-    kafka = nock('https://kafka-api.heroku.com:443')
+    kafka = nock('https://api.data.heroku.com:443')
     cli.mockConsole()
     cli.exit.mock()
   })

--- a/test/commands/upgrade_test.js
+++ b/test/commands/upgrade_test.js
@@ -42,7 +42,7 @@ describe('kafka:upgrade', () => {
 
   beforeEach(() => {
     confirm = cli.confirmApp
-    kafka = nock('https://kafka-api.heroku.com:443')
+    kafka = nock('https://api.data.heroku.com:443')
 
     cli.confirmApp = confirmApp
     cli.mockConsole()

--- a/test/commands/wait_test.js
+++ b/test/commands/wait_test.js
@@ -37,7 +37,7 @@ describe('kafka:wait', () => {
   beforeEach(() => {
     cli.mockConsole()
     cli.exit.mock()
-    kafka = nock('https://kafka-api.heroku.com')
+    kafka = nock('https://api.data.heroku.com')
   })
 
   afterEach(() => {

--- a/test/commands/zookeeper_test.js
+++ b/test/commands/zookeeper_test.js
@@ -33,7 +33,7 @@ describe('kafka:zookeeper', () => {
 
   beforeEach(() => {
     planName = 'heroku-kafka:private-standard-2'
-    kafka = nock('https://kafka-api.heroku.com:443')
+    kafka = nock('https://api.data.heroku.com:443')
     cli.mockConsole()
     cli.exit.mock()
   })

--- a/test/lib/clusters_test.js
+++ b/test/lib/clusters_test.js
@@ -121,7 +121,7 @@ describe('topicConfig', () => {
     const topicName = 'foo'
     const heroku = {
       request: td.when(td.function()({
-        host: 'kafka-api.heroku.com',
+        host: 'api.data.heroku.com',
         accept: 'application/json',
         path: `/data/kafka/v0/clusters/${addonId}/topics`
       })).thenResolve({
@@ -141,7 +141,7 @@ describe('topicConfig', () => {
     const topicPrefix = 'wisła-3456.'
     const heroku = {
       request: td.when(td.function()({
-        host: 'kafka-api.heroku.com',
+        host: 'api.data.heroku.com',
         accept: 'application/json',
         path: `/data/kafka/v0/clusters/${addonId}/topics`
       })).thenResolve({
@@ -161,7 +161,7 @@ describe('topicConfig', () => {
     const topicPrefix = 'wisła-3456.'
     const heroku = {
       request: td.when(td.function()({
-        host: 'kafka-api.heroku.com',
+        host: 'api.data.heroku.com',
         accept: 'application/json',
         path: `/data/kafka/v0/clusters/${addonId}/topics`
       })).thenResolve({
@@ -180,7 +180,7 @@ describe('topicConfig', () => {
     const topicName = 'foo'
     const heroku = {
       request: td.when(td.function()({
-        host: 'kafka-api.heroku.com',
+        host: 'api.data.heroku.com',
         accept: 'application/json',
         path: `/data/kafka/v0/clusters/${addonId}/topics`
       })).thenResolve({


### PR DESCRIPTION
PR for [Updates default host to api.data.heroku.com](https://github.com/heroku/heroku-kafka-jsplugin/pull/219), but addressed to correct repo.