### PR TITLE
Switch back to the public GitHub Actions runners

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   tests:
     name: Tests
-    runs-on: pub-hk-ubuntu-22.04-small
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:


### PR DESCRIPTION
This repo was using one of the custom GitHub Actions runners when it did not need to (since it has no need of more compute, ARM CPUs or a static IP; public repos don't need a static IP for Git checkouts) - as proven by the fact that CI passes on this PR.

As such, it's been switched back to the standard GitHub Actions runners, as recommended here:
https://salesforce.quip.com/bu6UA0KImOxJ#temp:C:GZR57becb9df8d94f80b132168fd