### PR TITLE
fix: add esbuild platform packages to fix CI installation

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-include=optional

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,17 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -1430,11 +1441,138 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -91,5 +91,17 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.3"
+  },
+  "//": "WORKAROUND: Explicitly declare @esbuild platform packages to work around npm bug where optional dependencies for other platforms aren't included in package-lock.json (https://github.com/npm/cli/issues/8320). Without this, CI fails on Linux because @esbuild/linux-x64 is missing. These versions must match the esbuild version (currently 0.27.3) and should be updated when esbuild is updated.",
+  "optionalDependencies": {
+    "@esbuild/darwin-arm64": "0.27.3",
+    "@esbuild/darwin-x64": "0.27.3",
+    "@esbuild/linux-arm": "0.27.3",
+    "@esbuild/linux-arm64": "0.27.3",
+    "@esbuild/linux-ia32": "0.27.3",
+    "@esbuild/linux-x64": "0.27.3",
+    "@esbuild/win32-arm64": "0.27.3",
+    "@esbuild/win32-ia32": "0.27.3",
+    "@esbuild/win32-x64": "0.27.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   "overrides": {
     "serialize-javascript": "^7.0.3"
   },
-  "//": "WORKAROUND: Explicitly declare @esbuild platform packages to work around npm bug where optional dependencies for other platforms aren't included in package-lock.json (https://github.com/npm/cli/issues/8320). Without this, CI fails on Linux because @esbuild/linux-x64 is missing. These versions must match the esbuild version (currently 0.27.3) and should be updated when esbuild is updated.",
+  "//": "WORKAROUND: Explicitly declare @esbuild platform packages to work around npm bug where optional dependencies for other platforms aren't included in package-lock.json. Without this, release CI fails on Linux because @esbuild/linux-x64 is missing. These versions must match the esbuild version (currently 0.27.3) and should be updated when esbuild is updated. This workaround can be removed once we upgrade to Node.js 24+ (which ships with npm 11 where this bug is fixed).",
   "optionalDependencies": {
     "@esbuild/darwin-arm64": "0.27.3",
     "@esbuild/darwin-x64": "0.27.3",


### PR DESCRIPTION
## Summary

Fixes release CI failure where tests fail with error: "The package '@esbuild/linux-x64' could not be found, and is needed by esbuild."

This is caused by an npm bug (npm/cli#8320) where optional dependencies for other platforms aren't included in package-lock.json. When the lockfile is generated on macOS, only darwin-arm64 is included. When CI runs on Linux x64, it can't find @esbuild/linux-x64 in the lockfile, so it doesn't install it, causing tsx to fail.

**Solution**: Explicitly declare @esbuild platform packages for macOS, Linux, and Windows as optionalDependencies. This forces npm to include them all in the lockfile. Each platform will still only install its matching package due to OS/CPU constraints.

## Type of Change

### Patch Updates (patch semver update)

- [x] **fix**: Bug fix

## Testing

**Notes**:

This fix allows CI to successfully install @esbuild/linux-x64 when running on Linux, which is required for tsx to work properly.

**Steps**:

1. Passing CI suffices - the validate job should now pass without the esbuild error.

## Screenshots (if applicable)

N/A

## Related Issues

- npm bug: https://github.com/npm/cli/issues/8320